### PR TITLE
use prometheus related name for exporter port

### DIFF
--- a/apis/kubedb/v1alpha1/annotations.go
+++ b/apis/kubedb/v1alpha1/annotations.go
@@ -22,5 +22,5 @@ const (
 
 	AgentCoreosPrometheus        = "coreos-prometheus-operator"
 	PrometheusExporterPortNumber = 56790
-	PrometheusExporterPortName   = "http"
+	PrometheusExporterPortName   = "prom-http"
 )


### PR DESCRIPTION
We can't name two ports same. It's better to keep `http` name free to be used in database container. 