### PR TITLE
Elasticsearch: Don't return http/https from Scheme function

### DIFF
--- a/apis/kubedb/v1alpha1/elasticsearch_helpers.go
+++ b/apis/kubedb/v1alpha1/elasticsearch_helpers.go
@@ -72,10 +72,7 @@ func (e elasticsearchStatsService) Path() string {
 }
 
 func (e elasticsearchStatsService) Scheme() string {
-	if e.Spec.EnableSSL {
-		return "https"
-	}
-	return "http"
+	return ""
 }
 
 func (e Elasticsearch) StatsService() mona.StatsAccessor {


### PR DESCRIPTION
**Reason:**
If Scheme function is used for determine http/https scheme, `agent.CreateOrUpdate(elasticsearch.StatsService(), elasticsearch.Spec.Monitor)` funtion inject this scheme in stats service annotation. As a result, promethuse try to connect with exporter using this scheme.