### PR TITLE
Remove database versions from "all" category

### DIFF
--- a/api/crds/elasticsearch.yaml
+++ b/api/crds/elasticsearch.yaml
@@ -8057,6 +8057,137 @@ spec:
               properties:
                 agent:
                   type: string
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: EnvVarSource represents a source for the value
+                          of an EnvVar.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key from a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or it's
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                          fieldRef:
+                            description: ObjectFieldSelector selects an APIVersioned
+                              field of an object.
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                          resourceFieldRef:
+                            description: ResourceFieldSelector represents container
+                              resources (cpu, memory) and their output format
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                description: |-
+                                  Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.
+
+                                  The serialization format is:
+
+                                  <quantity>        ::= <signedNumber><suffix>
+                                    (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                  <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                    (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                  <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                    (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                  <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                  No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                  When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                  Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                    a. No precision is lost
+                                    b. No fractional digits will be emitted
+                                    c. The exponent (or suffix) is as large as possible.
+                                  The sign will be omitted unless the number is negative.
+
+                                  Examples:
+                                    1.5 will be serialized as "1500m"
+                                    1.5Gi will be serialized as "1536Mi"
+
+                                  Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                  Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                  This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                type: string
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                          secretKeyRef:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or it's key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                    required:
+                    - name
+                  type: array
                 prometheus:
                   properties:
                     interval:
@@ -8088,6 +8219,93 @@ spec:
                         it defaults to Limits if that is explicitly specified, otherwise
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
+                securityContext:
+                  description: SecurityContext holds security configuration that will
+                    be applied to a container. Some fields are present in both SecurityContext
+                    and PodSecurityContext.  When both are set, the values in SecurityContext
+                    take precedence.
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: Adds and removes POSIX capabilities from running
+                        containers.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: SELinuxOptions are the labels to be applied to
+                        the container
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
             nodeSelector:
               description: 'NodeSelector is a selector which must be true for the
                 pod to fit on a node Deprecated: Use podTemplate.spec.nodeSelector'

--- a/api/crds/elasticsearchversion.yaml
+++ b/api/crds/elasticsearchversion.yaml
@@ -26,7 +26,6 @@ spec:
     - datastore
     - kubedb
     - appscode
-    - all
     kind: ElasticsearchVersion
     plural: elasticsearchversions
     shortNames:

--- a/api/crds/etcd.yaml
+++ b/api/crds/etcd.yaml
@@ -6293,6 +6293,137 @@ spec:
               properties:
                 agent:
                   type: string
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: EnvVarSource represents a source for the value
+                          of an EnvVar.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key from a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or it's
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                          fieldRef:
+                            description: ObjectFieldSelector selects an APIVersioned
+                              field of an object.
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                          resourceFieldRef:
+                            description: ResourceFieldSelector represents container
+                              resources (cpu, memory) and their output format
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                description: |-
+                                  Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.
+
+                                  The serialization format is:
+
+                                  <quantity>        ::= <signedNumber><suffix>
+                                    (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                  <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                    (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                  <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                    (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                  <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                  No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                  When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                  Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                    a. No precision is lost
+                                    b. No fractional digits will be emitted
+                                    c. The exponent (or suffix) is as large as possible.
+                                  The sign will be omitted unless the number is negative.
+
+                                  Examples:
+                                    1.5 will be serialized as "1500m"
+                                    1.5Gi will be serialized as "1536Mi"
+
+                                  Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                  Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                  This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                type: string
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                          secretKeyRef:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or it's key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                    required:
+                    - name
+                  type: array
                 prometheus:
                   properties:
                     interval:
@@ -6324,6 +6455,93 @@ spec:
                         it defaults to Limits if that is explicitly specified, otherwise
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
+                securityContext:
+                  description: SecurityContext holds security configuration that will
+                    be applied to a container. Some fields are present in both SecurityContext
+                    and PodSecurityContext.  When both are set, the values in SecurityContext
+                    take precedence.
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: Adds and removes POSIX capabilities from running
+                        containers.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: SELinuxOptions are the labels to be applied to
+                        the container
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
             podTemplate:
               description: PodTemplateSpec describes the data a pod should have when
                 created from a template

--- a/api/crds/etcdversion.yaml
+++ b/api/crds/etcdversion.yaml
@@ -26,7 +26,6 @@ spec:
     - datastore
     - kubedb
     - appscode
-    - all
     kind: EtcdVersion
     plural: etcdversions
     shortNames:

--- a/api/crds/memcached.yaml
+++ b/api/crds/memcached.yaml
@@ -2034,6 +2034,137 @@ spec:
               properties:
                 agent:
                   type: string
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: EnvVarSource represents a source for the value
+                          of an EnvVar.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key from a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or it's
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                          fieldRef:
+                            description: ObjectFieldSelector selects an APIVersioned
+                              field of an object.
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                          resourceFieldRef:
+                            description: ResourceFieldSelector represents container
+                              resources (cpu, memory) and their output format
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                description: |-
+                                  Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.
+
+                                  The serialization format is:
+
+                                  <quantity>        ::= <signedNumber><suffix>
+                                    (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                  <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                    (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                  <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                    (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                  <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                  No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                  When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                  Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                    a. No precision is lost
+                                    b. No fractional digits will be emitted
+                                    c. The exponent (or suffix) is as large as possible.
+                                  The sign will be omitted unless the number is negative.
+
+                                  Examples:
+                                    1.5 will be serialized as "1500m"
+                                    1.5Gi will be serialized as "1536Mi"
+
+                                  Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                  Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                  This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                type: string
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                          secretKeyRef:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or it's key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                    required:
+                    - name
+                  type: array
                 prometheus:
                   properties:
                     interval:
@@ -2065,6 +2196,93 @@ spec:
                         it defaults to Limits if that is explicitly specified, otherwise
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
+                securityContext:
+                  description: SecurityContext holds security configuration that will
+                    be applied to a container. Some fields are present in both SecurityContext
+                    and PodSecurityContext.  When both are set, the values in SecurityContext
+                    take precedence.
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: Adds and removes POSIX capabilities from running
+                        containers.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: SELinuxOptions are the labels to be applied to
+                        the container
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
             nodeSelector:
               description: 'NodeSelector is a selector which must be true for the
                 pod to fit on a node Deprecated: Use podTemplate.spec.nodeSelector'

--- a/api/crds/memcachedversion.yaml
+++ b/api/crds/memcachedversion.yaml
@@ -26,7 +26,6 @@ spec:
     - datastore
     - kubedb
     - appscode
-    - all
     kind: MemcachedVersion
     plural: memcachedversions
     shortNames:

--- a/api/crds/mongodb.yaml
+++ b/api/crds/mongodb.yaml
@@ -7996,6 +7996,137 @@ spec:
               properties:
                 agent:
                   type: string
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: EnvVarSource represents a source for the value
+                          of an EnvVar.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key from a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or it's
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                          fieldRef:
+                            description: ObjectFieldSelector selects an APIVersioned
+                              field of an object.
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                          resourceFieldRef:
+                            description: ResourceFieldSelector represents container
+                              resources (cpu, memory) and their output format
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                description: |-
+                                  Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.
+
+                                  The serialization format is:
+
+                                  <quantity>        ::= <signedNumber><suffix>
+                                    (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                  <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                    (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                  <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                    (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                  <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                  No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                  When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                  Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                    a. No precision is lost
+                                    b. No fractional digits will be emitted
+                                    c. The exponent (or suffix) is as large as possible.
+                                  The sign will be omitted unless the number is negative.
+
+                                  Examples:
+                                    1.5 will be serialized as "1500m"
+                                    1.5Gi will be serialized as "1536Mi"
+
+                                  Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                  Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                  This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                type: string
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                          secretKeyRef:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or it's key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                    required:
+                    - name
+                  type: array
                 prometheus:
                   properties:
                     interval:
@@ -8027,6 +8158,93 @@ spec:
                         it defaults to Limits if that is explicitly specified, otherwise
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
+                securityContext:
+                  description: SecurityContext holds security configuration that will
+                    be applied to a container. Some fields are present in both SecurityContext
+                    and PodSecurityContext.  When both are set, the values in SecurityContext
+                    take precedence.
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: Adds and removes POSIX capabilities from running
+                        containers.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: SELinuxOptions are the labels to be applied to
+                        the container
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
             nodeSelector:
               description: 'NodeSelector is a selector which must be true for the
                 pod to fit on a node Deprecated: Use podTemplate.spec.nodeSelector'

--- a/api/crds/mongodbversion.yaml
+++ b/api/crds/mongodbversion.yaml
@@ -26,7 +26,6 @@ spec:
     - datastore
     - kubedb
     - appscode
-    - all
     kind: MongoDBVersion
     plural: mongodbversions
     shortNames:

--- a/api/crds/mysql.yaml
+++ b/api/crds/mysql.yaml
@@ -7996,6 +7996,137 @@ spec:
               properties:
                 agent:
                   type: string
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: EnvVarSource represents a source for the value
+                          of an EnvVar.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key from a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or it's
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                          fieldRef:
+                            description: ObjectFieldSelector selects an APIVersioned
+                              field of an object.
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                          resourceFieldRef:
+                            description: ResourceFieldSelector represents container
+                              resources (cpu, memory) and their output format
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                description: |-
+                                  Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.
+
+                                  The serialization format is:
+
+                                  <quantity>        ::= <signedNumber><suffix>
+                                    (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                  <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                    (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                  <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                    (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                  <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                  No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                  When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                  Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                    a. No precision is lost
+                                    b. No fractional digits will be emitted
+                                    c. The exponent (or suffix) is as large as possible.
+                                  The sign will be omitted unless the number is negative.
+
+                                  Examples:
+                                    1.5 will be serialized as "1500m"
+                                    1.5Gi will be serialized as "1536Mi"
+
+                                  Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                  Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                  This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                type: string
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                          secretKeyRef:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or it's key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                    required:
+                    - name
+                  type: array
                 prometheus:
                   properties:
                     interval:
@@ -8027,6 +8158,93 @@ spec:
                         it defaults to Limits if that is explicitly specified, otherwise
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
+                securityContext:
+                  description: SecurityContext holds security configuration that will
+                    be applied to a container. Some fields are present in both SecurityContext
+                    and PodSecurityContext.  When both are set, the values in SecurityContext
+                    take precedence.
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: Adds and removes POSIX capabilities from running
+                        containers.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: SELinuxOptions are the labels to be applied to
+                        the container
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
             nodeSelector:
               description: 'NodeSelector is a selector which must be true for the
                 pod to fit on a node Deprecated: Use podTemplate.spec.nodeSelector'

--- a/api/crds/mysqlversion.yaml
+++ b/api/crds/mysqlversion.yaml
@@ -26,7 +26,6 @@ spec:
     - datastore
     - kubedb
     - appscode
-    - all
     kind: MySQLVersion
     plural: mysqlversions
     shortNames:

--- a/api/crds/postgres.yaml
+++ b/api/crds/postgres.yaml
@@ -9231,6 +9231,137 @@ spec:
               properties:
                 agent:
                   type: string
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: EnvVarSource represents a source for the value
+                          of an EnvVar.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key from a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or it's
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                          fieldRef:
+                            description: ObjectFieldSelector selects an APIVersioned
+                              field of an object.
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                          resourceFieldRef:
+                            description: ResourceFieldSelector represents container
+                              resources (cpu, memory) and their output format
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                description: |-
+                                  Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.
+
+                                  The serialization format is:
+
+                                  <quantity>        ::= <signedNumber><suffix>
+                                    (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                  <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                    (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                  <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                    (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                  <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                  No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                  When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                  Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                    a. No precision is lost
+                                    b. No fractional digits will be emitted
+                                    c. The exponent (or suffix) is as large as possible.
+                                  The sign will be omitted unless the number is negative.
+
+                                  Examples:
+                                    1.5 will be serialized as "1500m"
+                                    1.5Gi will be serialized as "1536Mi"
+
+                                  Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                  Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                  This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                type: string
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                          secretKeyRef:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or it's key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                    required:
+                    - name
+                  type: array
                 prometheus:
                   properties:
                     interval:
@@ -9262,6 +9393,93 @@ spec:
                         it defaults to Limits if that is explicitly specified, otherwise
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
+                securityContext:
+                  description: SecurityContext holds security configuration that will
+                    be applied to a container. Some fields are present in both SecurityContext
+                    and PodSecurityContext.  When both are set, the values in SecurityContext
+                    take precedence.
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: Adds and removes POSIX capabilities from running
+                        containers.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: SELinuxOptions are the labels to be applied to
+                        the container
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
             nodeSelector:
               description: 'NodeSelector is a selector which must be true for the
                 pod to fit on a node Deprecated: Use podTemplate.spec.nodeSelector'

--- a/api/crds/postgresversion.yaml
+++ b/api/crds/postgresversion.yaml
@@ -26,7 +26,6 @@ spec:
     - datastore
     - kubedb
     - appscode
-    - all
     kind: PostgresVersion
     plural: postgresversions
     shortNames:

--- a/api/crds/redis.yaml
+++ b/api/crds/redis.yaml
@@ -2050,6 +2050,137 @@ spec:
               properties:
                 agent:
                   type: string
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  items:
+                    type: string
+                  type: array
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: EnvVarSource represents a source for the value
+                          of an EnvVar.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key from a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or it's
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                          fieldRef:
+                            description: ObjectFieldSelector selects an APIVersioned
+                              field of an object.
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                          resourceFieldRef:
+                            description: ResourceFieldSelector represents container
+                              resources (cpu, memory) and their output format
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                description: |-
+                                  Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and Int64() accessors.
+
+                                  The serialization format is:
+
+                                  <quantity>        ::= <signedNumber><suffix>
+                                    (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                  <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                    (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                  <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                    (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                  <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                  No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                  When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                  Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                    a. No precision is lost
+                                    b. No fractional digits will be emitted
+                                    c. The exponent (or suffix) is as large as possible.
+                                  The sign will be omitted unless the number is negative.
+
+                                  Examples:
+                                    1.5 will be serialized as "1500m"
+                                    1.5Gi will be serialized as "1536Mi"
+
+                                  Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                  Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                  This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                type: string
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                          secretKeyRef:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or it's key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                    required:
+                    - name
+                  type: array
                 prometheus:
                   properties:
                     interval:
@@ -2081,6 +2212,93 @@ spec:
                         it defaults to Limits if that is explicitly specified, otherwise
                         to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
+                securityContext:
+                  description: SecurityContext holds security configuration that will
+                    be applied to a container. Some fields are present in both SecurityContext
+                    and PodSecurityContext.  When both are set, the values in SecurityContext
+                    take precedence.
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: Adds and removes POSIX capabilities from running
+                        containers.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: SELinuxOptions are the labels to be applied to
+                        the container
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
             nodeSelector:
               description: 'NodeSelector is a selector which must be true for the
                 pod to fit on a node Deprecated: Use podTemplate.spec.nodeSelector'

--- a/api/crds/redisversion.yaml
+++ b/api/crds/redisversion.yaml
@@ -26,7 +26,6 @@ spec:
     - datastore
     - kubedb
     - appscode
-    - all
     kind: RedisVersion
     plural: redisversions
     shortNames:

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -23516,12 +23516,32 @@
         "agent": {
           "type": "string"
         },
+        "args": {
+          "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "description": "List of environment variables to set in the container. Cannot be updated.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
+          },
+          "x-kubernetes-patch-merge-key": "name",
+          "x-kubernetes-patch-strategy": "merge"
+        },
         "prometheus": {
           "$ref": "#/definitions/xyz.kmodules.monitoring-agent-api.api.v1.PrometheusSpec"
         },
         "resources": {
-          "description": "Compute Resources required by the exporter container.",
+          "description": "Compute Resources required by exporter container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
           "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+        },
+        "securityContext": {
+          "description": "Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext"
         }
       }
     },

--- a/apis/authorization/v1alpha1/openapi_generated.go
+++ b/apis/authorization/v1alpha1/openapi_generated.go
@@ -337,11 +337,17 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/apimachinery/pkg/runtime.Unknown":                                                   schema_k8sio_apimachinery_pkg_runtime_Unknown(ref),
 		"k8s.io/apimachinery/pkg/util/intstr.IntOrString":                                           schema_apimachinery_pkg_util_intstr_IntOrString(ref),
 		"k8s.io/apimachinery/pkg/version.Info":                                                      schema_k8sio_apimachinery_pkg_version_Info(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeyTransform":                    schema_custom_resources_apis_appcatalog_v1alpha1_AddKeyTransform(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeysFromTransform":               schema_custom_resources_apis_appcatalog_v1alpha1_AddKeysFromTransform(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AppBinding":                         schema_custom_resources_apis_appcatalog_v1alpha1_AppBinding(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AppBindingList":                     schema_custom_resources_apis_appcatalog_v1alpha1_AppBindingList(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AppBindingSpec":                     schema_custom_resources_apis_appcatalog_v1alpha1_AppBindingSpec(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AppReference":                       schema_custom_resources_apis_appcatalog_v1alpha1_AppReference(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ClientConfig":                       schema_custom_resources_apis_appcatalog_v1alpha1_ClientConfig(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ObjectReference":                    schema_custom_resources_apis_appcatalog_v1alpha1_ObjectReference(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RemoveKeyTransform":                 schema_custom_resources_apis_appcatalog_v1alpha1_RemoveKeyTransform(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RenameKeyTransform":                 schema_custom_resources_apis_appcatalog_v1alpha1_RenameKeyTransform(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.SecretTransform":                    schema_custom_resources_apis_appcatalog_v1alpha1_SecretTransform(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ServiceReference":                   schema_custom_resources_apis_appcatalog_v1alpha1_ServiceReference(ref),
 		"kmodules.xyz/monitoring-agent-api/api/v1.AgentSpec":                                        schema_kmodulesxyz_monitoring_agent_api_api_v1_AgentSpec(ref),
 		"kmodules.xyz/monitoring-agent-api/api/v1.PrometheusSpec":                                   schema_kmodulesxyz_monitoring_agent_api_api_v1_PrometheusSpec(ref),
@@ -14918,6 +14924,68 @@ func schema_k8sio_apimachinery_pkg_version_Info(ref common.ReferenceCallback) co
 	}
 }
 
+func schema_custom_resources_apis_appcatalog_v1alpha1_AddKeyTransform(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "AddKeyTransform specifies that Service Catalog should add an additional entry to the Secret associated with the ServiceBinding. For example, given the following AddKeyTransform:\n    {\"key\": \"CONNECTION_POOL_SIZE\", \"stringValue\": \"10\"}\nthe following entry will appear in the Secret:\n    \"CONNECTION_POOL_SIZE\": \"10\"\nNote that this transform should only be used to add non-sensitive (non-secret) values. To add sensitive information, the AddKeysFromTransform should be used instead.",
+				Properties: map[string]spec.Schema{
+					"key": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The name of the key to add",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"value": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The binary value (possibly non-string) to add to the Secret under the specified key. If both value and stringValue are specified, then value is ignored and stringValue is stored.",
+							Type:        []string{"string"},
+							Format:      "byte",
+						},
+					},
+					"stringValue": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The string (non-binary) value to add to the Secret under the specified key.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"jsonPathExpression": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The JSONPath expression, the result of which will be added to the Secret under the specified key. For example, given the following credentials: { \"foo\": { \"bar\": \"foobar\" } } and the jsonPathExpression \"{.foo.bar}\", the value \"foobar\" will be stored in the credentials Secret under the specified key.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"key", "value", "stringValue", "jsonPathExpression"},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_custom_resources_apis_appcatalog_v1alpha1_AddKeysFromTransform(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "AddKeysFromTransform specifies that Service Catalog should merge an existing secret into the Secret associated with the ServiceBinding. For example, given the following AddKeysFromTransform:\n    {\"secretRef\": {\"namespace\": \"foo\", \"name\": \"bar\"}}\nthe entries of the Secret \"bar\" from Namespace \"foo\" will be merged into the credentials Secret.",
+				Properties: map[string]spec.Schema{
+					"secretRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The reference to the Secret that should be merged into the credentials Secret.",
+							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ObjectReference"),
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ObjectReference"},
+	}
+}
+
 func schema_custom_resources_apis_appcatalog_v1alpha1_AppBinding(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
@@ -15027,6 +15095,19 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_AppBindingSpec(ref common.
 							Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
 						},
 					},
+					"secretTransforms": {
+						SchemaProps: spec.SchemaProps{
+							Description: "List of transformations that should be applied to the credentials associated with the ServiceBinding before they are inserted into the Secret.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.SecretTransform"),
+									},
+								},
+							},
+						},
+					},
 					"parameters": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Parameters is a set of the parameters to be used to connect to the app. The inline YAML/JSON payload to be translated into equivalent JSON object.\n\nThe Parameters field is NOT secret or secured in any way and should NEVER be used to hold sensitive information. To set parameters that contain secret information, you should ALWAYS store that information in a Secret.",
@@ -15038,7 +15119,7 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_AppBindingSpec(ref common.
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/apimachinery/pkg/runtime.RawExtension", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ClientConfig"},
+			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/apimachinery/pkg/runtime.RawExtension", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ClientConfig", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.SecretTransform"},
 	}
 }
 
@@ -15117,6 +15198,120 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_ClientConfig(ref common.Re
 	}
 }
 
+func schema_custom_resources_apis_appcatalog_v1alpha1_ObjectReference(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ObjectReference contains enough information to let you locate the referenced object.",
+				Properties: map[string]spec.Schema{
+					"namespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Namespace of the referent.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the referent.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_custom_resources_apis_appcatalog_v1alpha1_RemoveKeyTransform(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "RemoveKeyTransform specifies that one of the credentials keys returned from the broker should not be included in the credentials Secret.",
+				Properties: map[string]spec.Schema{
+					"key": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The key to remove from the Secret",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"key"},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_custom_resources_apis_appcatalog_v1alpha1_RenameKeyTransform(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "RenameKeyTransform specifies that one of the credentials keys returned from the broker should be renamed and stored under a different key in the Secret. For example, given the following credentials entry:\n    \"USERNAME\": \"johndoe\"\nand the following RenameKeyTransform:\n    {\"from\": \"USERNAME\", \"to\": \"DB_USER\"}\nthe following entry will appear in the Secret:\n    \"DB_USER\": \"johndoe\"",
+				Properties: map[string]spec.Schema{
+					"from": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The name of the key to rename",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"to": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The new name for the key",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"from", "to"},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_custom_resources_apis_appcatalog_v1alpha1_SecretTransform(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "SecretTransform is a single transformation that is applied to the credentials returned from the broker before they are inserted into the Secret associated with the ServiceBinding. Because different brokers providing the same type of service may each return a different credentials structure, users can specify the transformations that should be applied to the Secret to adapt its entries to whatever the service consumer expects. For example, the credentials returned by the broker may include the key \"USERNAME\", but the consumer requires the username to be exposed under the key \"DB_USER\" instead. To have the Service Catalog transform the Secret, the following SecretTransform must be specified in ServiceBinding.spec.secretTransform: - {\"renameKey\": {\"from\": \"USERNAME\", \"to\": \"DB_USER\"}} Only one of the SecretTransform's members may be specified.",
+				Properties: map[string]spec.Schema{
+					"renameKey": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RenameKey represents a transform that renames a credentials Secret entry's key",
+							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RenameKeyTransform"),
+						},
+					},
+					"addKey": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AddKey represents a transform that adds an additional key to the credentials Secret",
+							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeyTransform"),
+						},
+					},
+					"addKeysFrom": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AddKeysFrom represents a transform that merges all the entries of an existing Secret into the credentials Secret",
+							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeysFromTransform"),
+						},
+					},
+					"removeKey": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RemoveKey represents a transform that removes a credentials Secret entry",
+							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RemoveKeyTransform"),
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeyTransform", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeysFromTransform", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RemoveKeyTransform", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RenameKeyTransform"},
+	}
+}
+
 func schema_custom_resources_apis_appcatalog_v1alpha1_ServiceReference(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
@@ -15151,6 +15346,13 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_ServiceReference(ref commo
 							Format:      "",
 						},
 					},
+					"query": {
+						SchemaProps: spec.SchemaProps{
+							Description: "`query` is optional encoded query string, without '?' which will be sent in any request to this service.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"scheme", "name", "port"},
 			},
@@ -15175,17 +15377,56 @@ func schema_kmodulesxyz_monitoring_agent_api_api_v1_AgentSpec(ref common.Referen
 							Ref: ref("kmodules.xyz/monitoring-agent-api/api/v1.PrometheusSpec"),
 						},
 					},
+					"args": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"env": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "List of environment variables to set in the container. Cannot be updated.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.EnvVar"),
+									},
+								},
+							},
+						},
+					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Compute Resources required by the exporter container.",
+							Description: "Compute Resources required by exporter container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
 							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
+						},
+					},
+					"securityContext": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+							Ref:         ref("k8s.io/api/core/v1.SecurityContext"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.ResourceRequirements", "kmodules.xyz/monitoring-agent-api/api/v1.PrometheusSpec"},
+			"k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.SecurityContext", "kmodules.xyz/monitoring-agent-api/api/v1.PrometheusSpec"},
 	}
 }
 

--- a/apis/catalog/v1alpha1/elasticsearch_version_helpers.go
+++ b/apis/catalog/v1alpha1/elasticsearch_version_helpers.go
@@ -31,7 +31,7 @@ func (p ElasticsearchVersion) CustomResourceDefinition() *apiextensions.CustomRe
 		Singular:      ResourceSingularElasticsearchVersion,
 		Kind:          ResourceKindElasticsearchVersion,
 		ShortNames:    []string{ResourceCodeElasticsearchVersion},
-		Categories:    []string{"datastore", "kubedb", "appscode", "all"},
+		Categories:    []string{"datastore", "kubedb", "appscode"},
 		ResourceScope: string(apiextensions.ClusterScoped),
 		Versions: []apiextensions.CustomResourceDefinitionVersion{
 			{

--- a/apis/catalog/v1alpha1/etcd_version_helpers.go
+++ b/apis/catalog/v1alpha1/etcd_version_helpers.go
@@ -31,7 +31,7 @@ func (p EtcdVersion) CustomResourceDefinition() *apiextensions.CustomResourceDef
 		Singular:      ResourceSingularEtcdVersion,
 		Kind:          ResourceKindEtcdVersion,
 		ShortNames:    []string{ResourceCodeEtcdVersion},
-		Categories:    []string{"datastore", "kubedb", "appscode", "all"},
+		Categories:    []string{"datastore", "kubedb", "appscode"},
 		ResourceScope: string(apiextensions.ClusterScoped),
 		Versions: []apiextensions.CustomResourceDefinitionVersion{
 			{

--- a/apis/catalog/v1alpha1/memcached_version_helpers.go
+++ b/apis/catalog/v1alpha1/memcached_version_helpers.go
@@ -31,7 +31,7 @@ func (p MemcachedVersion) CustomResourceDefinition() *apiextensions.CustomResour
 		Singular:      ResourceSingularMemcachedVersion,
 		Kind:          ResourceKindMemcachedVersion,
 		ShortNames:    []string{ResourceCodeMemcachedVersion},
-		Categories:    []string{"datastore", "kubedb", "appscode", "all"},
+		Categories:    []string{"datastore", "kubedb", "appscode"},
 		ResourceScope: string(apiextensions.ClusterScoped),
 		Versions: []apiextensions.CustomResourceDefinitionVersion{
 			{

--- a/apis/catalog/v1alpha1/mongodb_version_helpers.go
+++ b/apis/catalog/v1alpha1/mongodb_version_helpers.go
@@ -31,7 +31,7 @@ func (p MongoDBVersion) CustomResourceDefinition() *apiextensions.CustomResource
 		Singular:      ResourceSingularMongoDBVersion,
 		Kind:          ResourceKindMongoDBVersion,
 		ShortNames:    []string{ResourceCodeMongoDBVersion},
-		Categories:    []string{"datastore", "kubedb", "appscode", "all"},
+		Categories:    []string{"datastore", "kubedb", "appscode"},
 		ResourceScope: string(apiextensions.ClusterScoped),
 		Versions: []apiextensions.CustomResourceDefinitionVersion{
 			{

--- a/apis/catalog/v1alpha1/mysql_version_helpers.go
+++ b/apis/catalog/v1alpha1/mysql_version_helpers.go
@@ -31,7 +31,7 @@ func (p MySQLVersion) CustomResourceDefinition() *apiextensions.CustomResourceDe
 		Singular:      ResourceSingularMySQLVersion,
 		Kind:          ResourceKindMySQLVersion,
 		ShortNames:    []string{ResourceCodeMySQLVersion},
-		Categories:    []string{"datastore", "kubedb", "appscode", "all"},
+		Categories:    []string{"datastore", "kubedb", "appscode"},
 		ResourceScope: string(apiextensions.ClusterScoped),
 		Versions: []apiextensions.CustomResourceDefinitionVersion{
 			{

--- a/apis/catalog/v1alpha1/openapi_generated.go
+++ b/apis/catalog/v1alpha1/openapi_generated.go
@@ -355,11 +355,17 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/apimachinery/pkg/runtime.Unknown":                                           schema_k8sio_apimachinery_pkg_runtime_Unknown(ref),
 		"k8s.io/apimachinery/pkg/util/intstr.IntOrString":                                   schema_apimachinery_pkg_util_intstr_IntOrString(ref),
 		"k8s.io/apimachinery/pkg/version.Info":                                              schema_k8sio_apimachinery_pkg_version_Info(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeyTransform":            schema_custom_resources_apis_appcatalog_v1alpha1_AddKeyTransform(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeysFromTransform":       schema_custom_resources_apis_appcatalog_v1alpha1_AddKeysFromTransform(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AppBinding":                 schema_custom_resources_apis_appcatalog_v1alpha1_AppBinding(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AppBindingList":             schema_custom_resources_apis_appcatalog_v1alpha1_AppBindingList(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AppBindingSpec":             schema_custom_resources_apis_appcatalog_v1alpha1_AppBindingSpec(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AppReference":               schema_custom_resources_apis_appcatalog_v1alpha1_AppReference(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ClientConfig":               schema_custom_resources_apis_appcatalog_v1alpha1_ClientConfig(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ObjectReference":            schema_custom_resources_apis_appcatalog_v1alpha1_ObjectReference(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RemoveKeyTransform":         schema_custom_resources_apis_appcatalog_v1alpha1_RemoveKeyTransform(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RenameKeyTransform":         schema_custom_resources_apis_appcatalog_v1alpha1_RenameKeyTransform(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.SecretTransform":            schema_custom_resources_apis_appcatalog_v1alpha1_SecretTransform(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ServiceReference":           schema_custom_resources_apis_appcatalog_v1alpha1_ServiceReference(ref),
 		"kmodules.xyz/monitoring-agent-api/api/v1.AgentSpec":                                schema_kmodulesxyz_monitoring_agent_api_api_v1_AgentSpec(ref),
 		"kmodules.xyz/monitoring-agent-api/api/v1.PrometheusSpec":                           schema_kmodulesxyz_monitoring_agent_api_api_v1_PrometheusSpec(ref),
@@ -15214,6 +15220,68 @@ func schema_k8sio_apimachinery_pkg_version_Info(ref common.ReferenceCallback) co
 	}
 }
 
+func schema_custom_resources_apis_appcatalog_v1alpha1_AddKeyTransform(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "AddKeyTransform specifies that Service Catalog should add an additional entry to the Secret associated with the ServiceBinding. For example, given the following AddKeyTransform:\n    {\"key\": \"CONNECTION_POOL_SIZE\", \"stringValue\": \"10\"}\nthe following entry will appear in the Secret:\n    \"CONNECTION_POOL_SIZE\": \"10\"\nNote that this transform should only be used to add non-sensitive (non-secret) values. To add sensitive information, the AddKeysFromTransform should be used instead.",
+				Properties: map[string]spec.Schema{
+					"key": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The name of the key to add",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"value": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The binary value (possibly non-string) to add to the Secret under the specified key. If both value and stringValue are specified, then value is ignored and stringValue is stored.",
+							Type:        []string{"string"},
+							Format:      "byte",
+						},
+					},
+					"stringValue": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The string (non-binary) value to add to the Secret under the specified key.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"jsonPathExpression": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The JSONPath expression, the result of which will be added to the Secret under the specified key. For example, given the following credentials: { \"foo\": { \"bar\": \"foobar\" } } and the jsonPathExpression \"{.foo.bar}\", the value \"foobar\" will be stored in the credentials Secret under the specified key.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"key", "value", "stringValue", "jsonPathExpression"},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_custom_resources_apis_appcatalog_v1alpha1_AddKeysFromTransform(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "AddKeysFromTransform specifies that Service Catalog should merge an existing secret into the Secret associated with the ServiceBinding. For example, given the following AddKeysFromTransform:\n    {\"secretRef\": {\"namespace\": \"foo\", \"name\": \"bar\"}}\nthe entries of the Secret \"bar\" from Namespace \"foo\" will be merged into the credentials Secret.",
+				Properties: map[string]spec.Schema{
+					"secretRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The reference to the Secret that should be merged into the credentials Secret.",
+							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ObjectReference"),
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ObjectReference"},
+	}
+}
+
 func schema_custom_resources_apis_appcatalog_v1alpha1_AppBinding(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
@@ -15323,6 +15391,19 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_AppBindingSpec(ref common.
 							Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
 						},
 					},
+					"secretTransforms": {
+						SchemaProps: spec.SchemaProps{
+							Description: "List of transformations that should be applied to the credentials associated with the ServiceBinding before they are inserted into the Secret.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.SecretTransform"),
+									},
+								},
+							},
+						},
+					},
 					"parameters": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Parameters is a set of the parameters to be used to connect to the app. The inline YAML/JSON payload to be translated into equivalent JSON object.\n\nThe Parameters field is NOT secret or secured in any way and should NEVER be used to hold sensitive information. To set parameters that contain secret information, you should ALWAYS store that information in a Secret.",
@@ -15334,7 +15415,7 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_AppBindingSpec(ref common.
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/apimachinery/pkg/runtime.RawExtension", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ClientConfig"},
+			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/apimachinery/pkg/runtime.RawExtension", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ClientConfig", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.SecretTransform"},
 	}
 }
 
@@ -15413,6 +15494,120 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_ClientConfig(ref common.Re
 	}
 }
 
+func schema_custom_resources_apis_appcatalog_v1alpha1_ObjectReference(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ObjectReference contains enough information to let you locate the referenced object.",
+				Properties: map[string]spec.Schema{
+					"namespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Namespace of the referent.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the referent.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_custom_resources_apis_appcatalog_v1alpha1_RemoveKeyTransform(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "RemoveKeyTransform specifies that one of the credentials keys returned from the broker should not be included in the credentials Secret.",
+				Properties: map[string]spec.Schema{
+					"key": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The key to remove from the Secret",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"key"},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_custom_resources_apis_appcatalog_v1alpha1_RenameKeyTransform(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "RenameKeyTransform specifies that one of the credentials keys returned from the broker should be renamed and stored under a different key in the Secret. For example, given the following credentials entry:\n    \"USERNAME\": \"johndoe\"\nand the following RenameKeyTransform:\n    {\"from\": \"USERNAME\", \"to\": \"DB_USER\"}\nthe following entry will appear in the Secret:\n    \"DB_USER\": \"johndoe\"",
+				Properties: map[string]spec.Schema{
+					"from": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The name of the key to rename",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"to": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The new name for the key",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"from", "to"},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_custom_resources_apis_appcatalog_v1alpha1_SecretTransform(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "SecretTransform is a single transformation that is applied to the credentials returned from the broker before they are inserted into the Secret associated with the ServiceBinding. Because different brokers providing the same type of service may each return a different credentials structure, users can specify the transformations that should be applied to the Secret to adapt its entries to whatever the service consumer expects. For example, the credentials returned by the broker may include the key \"USERNAME\", but the consumer requires the username to be exposed under the key \"DB_USER\" instead. To have the Service Catalog transform the Secret, the following SecretTransform must be specified in ServiceBinding.spec.secretTransform: - {\"renameKey\": {\"from\": \"USERNAME\", \"to\": \"DB_USER\"}} Only one of the SecretTransform's members may be specified.",
+				Properties: map[string]spec.Schema{
+					"renameKey": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RenameKey represents a transform that renames a credentials Secret entry's key",
+							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RenameKeyTransform"),
+						},
+					},
+					"addKey": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AddKey represents a transform that adds an additional key to the credentials Secret",
+							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeyTransform"),
+						},
+					},
+					"addKeysFrom": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AddKeysFrom represents a transform that merges all the entries of an existing Secret into the credentials Secret",
+							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeysFromTransform"),
+						},
+					},
+					"removeKey": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RemoveKey represents a transform that removes a credentials Secret entry",
+							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RemoveKeyTransform"),
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeyTransform", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeysFromTransform", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RemoveKeyTransform", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RenameKeyTransform"},
+	}
+}
+
 func schema_custom_resources_apis_appcatalog_v1alpha1_ServiceReference(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
@@ -15447,6 +15642,13 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_ServiceReference(ref commo
 							Format:      "",
 						},
 					},
+					"query": {
+						SchemaProps: spec.SchemaProps{
+							Description: "`query` is optional encoded query string, without '?' which will be sent in any request to this service.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"scheme", "name", "port"},
 			},
@@ -15471,17 +15673,56 @@ func schema_kmodulesxyz_monitoring_agent_api_api_v1_AgentSpec(ref common.Referen
 							Ref: ref("kmodules.xyz/monitoring-agent-api/api/v1.PrometheusSpec"),
 						},
 					},
+					"args": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"env": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "List of environment variables to set in the container. Cannot be updated.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.EnvVar"),
+									},
+								},
+							},
+						},
+					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Compute Resources required by the exporter container.",
+							Description: "Compute Resources required by exporter container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
 							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
+						},
+					},
+					"securityContext": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+							Ref:         ref("k8s.io/api/core/v1.SecurityContext"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.ResourceRequirements", "kmodules.xyz/monitoring-agent-api/api/v1.PrometheusSpec"},
+			"k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.SecurityContext", "kmodules.xyz/monitoring-agent-api/api/v1.PrometheusSpec"},
 	}
 }
 

--- a/apis/catalog/v1alpha1/postgres_version_helpers.go
+++ b/apis/catalog/v1alpha1/postgres_version_helpers.go
@@ -31,7 +31,7 @@ func (p PostgresVersion) CustomResourceDefinition() *apiextensions.CustomResourc
 		Singular:      ResourceSingularPostgresVersion,
 		Kind:          ResourceKindPostgresVersion,
 		ShortNames:    []string{ResourceCodePostgresVersion},
-		Categories:    []string{"datastore", "kubedb", "appscode", "all"},
+		Categories:    []string{"datastore", "kubedb", "appscode"},
 		ResourceScope: string(apiextensions.ClusterScoped),
 		Versions: []apiextensions.CustomResourceDefinitionVersion{
 			{

--- a/apis/catalog/v1alpha1/redis_version_helpers.go
+++ b/apis/catalog/v1alpha1/redis_version_helpers.go
@@ -31,7 +31,7 @@ func (p RedisVersion) CustomResourceDefinition() *apiextensions.CustomResourceDe
 		Singular:      ResourceSingularRedisVersion,
 		Kind:          ResourceKindRedisVersion,
 		ShortNames:    []string{ResourceCodeRedisVersion},
-		Categories:    []string{"datastore", "kubedb", "appscode", "all"},
+		Categories:    []string{"datastore", "kubedb", "appscode"},
 		ResourceScope: string(apiextensions.ClusterScoped),
 		Versions: []apiextensions.CustomResourceDefinitionVersion{
 			{

--- a/apis/kubedb/v1alpha1/openapi_generated.go
+++ b/apis/kubedb/v1alpha1/openapi_generated.go
@@ -387,11 +387,17 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/apimachinery/pkg/runtime.Unknown":                                          schema_k8sio_apimachinery_pkg_runtime_Unknown(ref),
 		"k8s.io/apimachinery/pkg/util/intstr.IntOrString":                                  schema_apimachinery_pkg_util_intstr_IntOrString(ref),
 		"k8s.io/apimachinery/pkg/version.Info":                                             schema_k8sio_apimachinery_pkg_version_Info(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeyTransform":           schema_custom_resources_apis_appcatalog_v1alpha1_AddKeyTransform(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeysFromTransform":      schema_custom_resources_apis_appcatalog_v1alpha1_AddKeysFromTransform(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AppBinding":                schema_custom_resources_apis_appcatalog_v1alpha1_AppBinding(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AppBindingList":            schema_custom_resources_apis_appcatalog_v1alpha1_AppBindingList(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AppBindingSpec":            schema_custom_resources_apis_appcatalog_v1alpha1_AppBindingSpec(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AppReference":              schema_custom_resources_apis_appcatalog_v1alpha1_AppReference(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ClientConfig":              schema_custom_resources_apis_appcatalog_v1alpha1_ClientConfig(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ObjectReference":           schema_custom_resources_apis_appcatalog_v1alpha1_ObjectReference(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RemoveKeyTransform":        schema_custom_resources_apis_appcatalog_v1alpha1_RemoveKeyTransform(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RenameKeyTransform":        schema_custom_resources_apis_appcatalog_v1alpha1_RenameKeyTransform(ref),
+		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.SecretTransform":           schema_custom_resources_apis_appcatalog_v1alpha1_SecretTransform(ref),
 		"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ServiceReference":          schema_custom_resources_apis_appcatalog_v1alpha1_ServiceReference(ref),
 		"kmodules.xyz/monitoring-agent-api/api/v1.AgentSpec":                               schema_kmodulesxyz_monitoring_agent_api_api_v1_AgentSpec(ref),
 		"kmodules.xyz/monitoring-agent-api/api/v1.PrometheusSpec":                          schema_kmodulesxyz_monitoring_agent_api_api_v1_PrometheusSpec(ref),
@@ -17402,6 +17408,68 @@ func schema_k8sio_apimachinery_pkg_version_Info(ref common.ReferenceCallback) co
 	}
 }
 
+func schema_custom_resources_apis_appcatalog_v1alpha1_AddKeyTransform(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "AddKeyTransform specifies that Service Catalog should add an additional entry to the Secret associated with the ServiceBinding. For example, given the following AddKeyTransform:\n    {\"key\": \"CONNECTION_POOL_SIZE\", \"stringValue\": \"10\"}\nthe following entry will appear in the Secret:\n    \"CONNECTION_POOL_SIZE\": \"10\"\nNote that this transform should only be used to add non-sensitive (non-secret) values. To add sensitive information, the AddKeysFromTransform should be used instead.",
+				Properties: map[string]spec.Schema{
+					"key": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The name of the key to add",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"value": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The binary value (possibly non-string) to add to the Secret under the specified key. If both value and stringValue are specified, then value is ignored and stringValue is stored.",
+							Type:        []string{"string"},
+							Format:      "byte",
+						},
+					},
+					"stringValue": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The string (non-binary) value to add to the Secret under the specified key.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"jsonPathExpression": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The JSONPath expression, the result of which will be added to the Secret under the specified key. For example, given the following credentials: { \"foo\": { \"bar\": \"foobar\" } } and the jsonPathExpression \"{.foo.bar}\", the value \"foobar\" will be stored in the credentials Secret under the specified key.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"key", "value", "stringValue", "jsonPathExpression"},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_custom_resources_apis_appcatalog_v1alpha1_AddKeysFromTransform(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "AddKeysFromTransform specifies that Service Catalog should merge an existing secret into the Secret associated with the ServiceBinding. For example, given the following AddKeysFromTransform:\n    {\"secretRef\": {\"namespace\": \"foo\", \"name\": \"bar\"}}\nthe entries of the Secret \"bar\" from Namespace \"foo\" will be merged into the credentials Secret.",
+				Properties: map[string]spec.Schema{
+					"secretRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The reference to the Secret that should be merged into the credentials Secret.",
+							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ObjectReference"),
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ObjectReference"},
+	}
+}
+
 func schema_custom_resources_apis_appcatalog_v1alpha1_AppBinding(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
@@ -17511,6 +17579,19 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_AppBindingSpec(ref common.
 							Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
 						},
 					},
+					"secretTransforms": {
+						SchemaProps: spec.SchemaProps{
+							Description: "List of transformations that should be applied to the credentials associated with the ServiceBinding before they are inserted into the Secret.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.SecretTransform"),
+									},
+								},
+							},
+						},
+					},
 					"parameters": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Parameters is a set of the parameters to be used to connect to the app. The inline YAML/JSON payload to be translated into equivalent JSON object.\n\nThe Parameters field is NOT secret or secured in any way and should NEVER be used to hold sensitive information. To set parameters that contain secret information, you should ALWAYS store that information in a Secret.",
@@ -17522,7 +17603,7 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_AppBindingSpec(ref common.
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/apimachinery/pkg/runtime.RawExtension", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ClientConfig"},
+			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/apimachinery/pkg/runtime.RawExtension", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ClientConfig", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.SecretTransform"},
 	}
 }
 
@@ -17601,6 +17682,120 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_ClientConfig(ref common.Re
 	}
 }
 
+func schema_custom_resources_apis_appcatalog_v1alpha1_ObjectReference(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ObjectReference contains enough information to let you locate the referenced object.",
+				Properties: map[string]spec.Schema{
+					"namespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Namespace of the referent.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the referent.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_custom_resources_apis_appcatalog_v1alpha1_RemoveKeyTransform(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "RemoveKeyTransform specifies that one of the credentials keys returned from the broker should not be included in the credentials Secret.",
+				Properties: map[string]spec.Schema{
+					"key": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The key to remove from the Secret",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"key"},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_custom_resources_apis_appcatalog_v1alpha1_RenameKeyTransform(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "RenameKeyTransform specifies that one of the credentials keys returned from the broker should be renamed and stored under a different key in the Secret. For example, given the following credentials entry:\n    \"USERNAME\": \"johndoe\"\nand the following RenameKeyTransform:\n    {\"from\": \"USERNAME\", \"to\": \"DB_USER\"}\nthe following entry will appear in the Secret:\n    \"DB_USER\": \"johndoe\"",
+				Properties: map[string]spec.Schema{
+					"from": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The name of the key to rename",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"to": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The new name for the key",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"from", "to"},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_custom_resources_apis_appcatalog_v1alpha1_SecretTransform(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "SecretTransform is a single transformation that is applied to the credentials returned from the broker before they are inserted into the Secret associated with the ServiceBinding. Because different brokers providing the same type of service may each return a different credentials structure, users can specify the transformations that should be applied to the Secret to adapt its entries to whatever the service consumer expects. For example, the credentials returned by the broker may include the key \"USERNAME\", but the consumer requires the username to be exposed under the key \"DB_USER\" instead. To have the Service Catalog transform the Secret, the following SecretTransform must be specified in ServiceBinding.spec.secretTransform: - {\"renameKey\": {\"from\": \"USERNAME\", \"to\": \"DB_USER\"}} Only one of the SecretTransform's members may be specified.",
+				Properties: map[string]spec.Schema{
+					"renameKey": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RenameKey represents a transform that renames a credentials Secret entry's key",
+							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RenameKeyTransform"),
+						},
+					},
+					"addKey": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AddKey represents a transform that adds an additional key to the credentials Secret",
+							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeyTransform"),
+						},
+					},
+					"addKeysFrom": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AddKeysFrom represents a transform that merges all the entries of an existing Secret into the credentials Secret",
+							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeysFromTransform"),
+						},
+					},
+					"removeKey": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RemoveKey represents a transform that removes a credentials Secret entry",
+							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RemoveKeyTransform"),
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeyTransform", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.AddKeysFromTransform", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RemoveKeyTransform", "kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.RenameKeyTransform"},
+	}
+}
+
 func schema_custom_resources_apis_appcatalog_v1alpha1_ServiceReference(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
@@ -17635,6 +17830,13 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_ServiceReference(ref commo
 							Format:      "",
 						},
 					},
+					"query": {
+						SchemaProps: spec.SchemaProps{
+							Description: "`query` is optional encoded query string, without '?' which will be sent in any request to this service.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"scheme", "name", "port"},
 			},
@@ -17659,17 +17861,56 @@ func schema_kmodulesxyz_monitoring_agent_api_api_v1_AgentSpec(ref common.Referen
 							Ref: ref("kmodules.xyz/monitoring-agent-api/api/v1.PrometheusSpec"),
 						},
 					},
+					"args": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"env": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "List of environment variables to set in the container. Cannot be updated.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.EnvVar"),
+									},
+								},
+							},
+						},
+					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Compute Resources required by the exporter container.",
+							Description: "Compute Resources required by exporter container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
 							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
+						},
+					},
+					"securityContext": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+							Ref:         ref("k8s.io/api/core/v1.SecurityContext"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.ResourceRequirements", "kmodules.xyz/monitoring-agent-api/api/v1.PrometheusSpec"},
+			"k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.SecurityContext", "kmodules.xyz/monitoring-agent-api/api/v1.PrometheusSpec"},
 	}
 }
 


### PR DESCRIPTION
This PR removes the version objects of the individual databases from the `all` category. IMHO they do not belong there, as they are cluster-wide resources and showing them on an `all` call, which is namespaced (not cluster-wide), produces very verbose messages without any valuable information.

Closes kubedb/project#375