### PR TITLE
Fix defaulting ClusterAuthMode

### DIFF
--- a/apis/kubedb/v1alpha1/mongodb_helpers.go
+++ b/apis/kubedb/v1alpha1/mongodb_helpers.go
@@ -364,7 +364,7 @@ func (m *MongoDBSpec) SetDefaults() {
 	}
 
 	if (m.ReplicaSet != nil || m.ShardTopology != nil) && m.ClusterAuthMode == "" {
-		if m.SSLMode == SSLModeDisabled {
+		if m.SSLMode == SSLModeDisabled || m.SSLMode == SSLModeAllowSSL {
 			m.ClusterAuthMode = ClusterAuthModeKeyFile
 		} else {
 			m.ClusterAuthMode = ClusterAuthModeX509


### PR DESCRIPTION
ClusterAuthMode can't be set to `x509` when sslMode is `allowSSL`.