### PR TITLE
Change default termination policy as Delete.

### DIFF
--- a/apis/kubedb/v1alpha1/elasticsearch_helpers.go
+++ b/apis/kubedb/v1alpha1/elasticsearch_helpers.go
@@ -206,11 +206,7 @@ func (e *ElasticsearchSpec) SetDefaults() {
 		e.UpdateStrategy.Type = apps.RollingUpdateStatefulSetStrategyType
 	}
 	if e.TerminationPolicy == "" {
-		if e.StorageType == StorageTypeEphemeral {
-			e.TerminationPolicy = TerminationPolicyDelete
-		} else {
-			e.TerminationPolicy = TerminationPolicyPause
-		}
+		e.TerminationPolicy = TerminationPolicyDelete
 	}
 }
 

--- a/apis/kubedb/v1alpha1/etcd_helpers.go
+++ b/apis/kubedb/v1alpha1/etcd_helpers.go
@@ -185,11 +185,7 @@ func (e *EtcdSpec) SetDefaults() {
 		e.UpdateStrategy.Type = apps.RollingUpdateStatefulSetStrategyType
 	}
 	if e.TerminationPolicy == "" {
-		if e.StorageType == StorageTypeEphemeral {
-			e.TerminationPolicy = TerminationPolicyDelete
-		} else {
-			e.TerminationPolicy = TerminationPolicyPause
-		}
+		e.TerminationPolicy = TerminationPolicyDelete
 	}
 }
 

--- a/apis/kubedb/v1alpha1/mariadb_helpers.go
+++ b/apis/kubedb/v1alpha1/mariadb_helpers.go
@@ -186,11 +186,7 @@ func (m *MariaDBSpec) SetDefaults() {
 		m.UpdateStrategy.Type = apps.RollingUpdateStatefulSetStrategyType
 	}
 	if m.TerminationPolicy == "" {
-		if m.StorageType == StorageTypeEphemeral {
-			m.TerminationPolicy = TerminationPolicyDelete
-		} else {
-			m.TerminationPolicy = TerminationPolicyPause
-		}
+		m.TerminationPolicy = TerminationPolicyDelete
 	}
 }
 

--- a/apis/kubedb/v1alpha1/memcached_helpers.go
+++ b/apis/kubedb/v1alpha1/memcached_helpers.go
@@ -177,7 +177,7 @@ func (m *MemcachedSpec) SetDefaults() {
 		m.UpdateStrategy.Type = apps.RollingUpdateDeploymentStrategyType
 	}
 	if m.TerminationPolicy == "" {
-		m.TerminationPolicy = TerminationPolicyPause
+		m.TerminationPolicy = TerminationPolicyDelete
 	}
 }
 

--- a/apis/kubedb/v1alpha1/mongodb_helpers.go
+++ b/apis/kubedb/v1alpha1/mongodb_helpers.go
@@ -357,11 +357,7 @@ func (m *MongoDBSpec) SetDefaults() {
 		m.UpdateStrategy.Type = apps.RollingUpdateStatefulSetStrategyType
 	}
 	if m.TerminationPolicy == "" {
-		if m.StorageType == StorageTypeEphemeral {
-			m.TerminationPolicy = TerminationPolicyDelete
-		} else {
-			m.TerminationPolicy = TerminationPolicyPause
-		}
+		m.TerminationPolicy = TerminationPolicyDelete
 	}
 
 	if m.SSLMode == "" {

--- a/apis/kubedb/v1alpha1/mysql_helpers.go
+++ b/apis/kubedb/v1alpha1/mysql_helpers.go
@@ -193,11 +193,7 @@ func (m *MySQLSpec) SetDefaults() {
 		m.UpdateStrategy.Type = apps.RollingUpdateStatefulSetStrategyType
 	}
 	if m.TerminationPolicy == "" {
-		if m.StorageType == StorageTypeEphemeral {
-			m.TerminationPolicy = TerminationPolicyDelete
-		} else {
-			m.TerminationPolicy = TerminationPolicyPause
-		}
+		m.TerminationPolicy = TerminationPolicyDelete
 	}
 
 	if m.Topology != nil && m.Topology.Mode != nil && *m.Topology.Mode == MySQLClusterModeGroup {

--- a/apis/kubedb/v1alpha1/perconaxtradb_helpers.go
+++ b/apis/kubedb/v1alpha1/perconaxtradb_helpers.go
@@ -249,11 +249,7 @@ func (p *PerconaXtraDBSpec) SetDefaults() {
 		p.UpdateStrategy.Type = apps.RollingUpdateStatefulSetStrategyType
 	}
 	if p.TerminationPolicy == "" {
-		if p.StorageType == StorageTypeEphemeral {
-			p.TerminationPolicy = TerminationPolicyDelete
-		} else {
-			p.TerminationPolicy = TerminationPolicyPause
-		}
+		p.TerminationPolicy = TerminationPolicyDelete
 	}
 }
 

--- a/apis/kubedb/v1alpha1/postgres_helpers.go
+++ b/apis/kubedb/v1alpha1/postgres_helpers.go
@@ -192,11 +192,7 @@ func (p *PostgresSpec) SetDefaults() {
 		p.UpdateStrategy.Type = apps.RollingUpdateStatefulSetStrategyType
 	}
 	if p.TerminationPolicy == "" {
-		if p.StorageType == StorageTypeEphemeral {
-			p.TerminationPolicy = TerminationPolicyDelete
-		} else {
-			p.TerminationPolicy = TerminationPolicyPause
-		}
+		p.TerminationPolicy = TerminationPolicyDelete
 	}
 	if p.Init != nil && p.Init.PostgresWAL != nil && p.Init.PostgresWAL.PITR != nil {
 		pitr := p.Init.PostgresWAL.PITR

--- a/apis/kubedb/v1alpha1/redis_helpers.go
+++ b/apis/kubedb/v1alpha1/redis_helpers.go
@@ -206,11 +206,7 @@ func (r *RedisSpec) SetDefaults() {
 		r.UpdateStrategy.Type = apps.RollingUpdateStatefulSetStrategyType
 	}
 	if r.TerminationPolicy == "" {
-		if r.StorageType == StorageTypeEphemeral {
-			r.TerminationPolicy = TerminationPolicyDelete
-		} else {
-			r.TerminationPolicy = TerminationPolicyPause
-		}
+		r.TerminationPolicy = TerminationPolicyDelete
 	}
 }
 

--- a/pkg/admission/namespace/admission.go
+++ b/pkg/admission/namespace/admission.go
@@ -105,7 +105,7 @@ func (a *NamespaceValidator) Admit(req *admission.AdmissionRequest) *admission.A
 						}
 						if found &&
 							(terminationPolicy == string(api.TerminationPolicyPause) ||
-							terminationPolicy == string(api.TerminationPolicyDoNotTerminate)) {
+								terminationPolicy == string(api.TerminationPolicyDoNotTerminate)) {
 							return fmt.Errorf("%s %s/%s has termination policy `%s`", u.GetKind(), u.GetNamespace(), u.GetName(), terminationPolicy)
 						}
 						return nil

--- a/pkg/admission/namespace/admission.go
+++ b/pkg/admission/namespace/admission.go
@@ -103,9 +103,9 @@ func (a *NamespaceValidator) Admit(req *admission.AdmissionRequest) *admission.A
 						if err != nil {
 							return err
 						}
-						if !found ||
-							terminationPolicy == string(api.TerminationPolicyPause) ||
-							terminationPolicy == string(api.TerminationPolicyDoNotTerminate) {
+						if found &&
+							(terminationPolicy == string(api.TerminationPolicyPause) ||
+							terminationPolicy == string(api.TerminationPolicyDoNotTerminate)) {
 							return fmt.Errorf("%s %s/%s has termination policy `%s`", u.GetKind(), u.GetNamespace(), u.GetName(), terminationPolicy)
 						}
 						return nil

--- a/pkg/admission/namespace/admission_test.go
+++ b/pkg/admission/namespace/admission_test.go
@@ -152,7 +152,7 @@ var cases = []struct {
 		admission.Delete,
 		sampleNamespace(),
 		[]*unstructured.Unstructured{deleteTerminationPolicy(sampleDatabase())},
-		false,
+		true,
 	},
 }
 


### PR DESCRIPTION
Before if no termination policy was set, we will consider it as DoNotTerminate.
I think this is too restrictive. This blocks namespace deletion.
Now, we only consider explicitly set termination policy.

Signed-off-by: Tamal Saha <tamal@appscode.com>