### PR TITLE
Remove extra - from prefix/suffix

### DIFF
--- a/apis/kubedb/v1alpha1/constants.go
+++ b/apis/kubedb/v1alpha1/constants.go
@@ -56,11 +56,11 @@ const (
 	MongoDBShardPort                  = 27017
 	MongoDBConfigdbPort               = 27017
 	MongoDBMongosPort                 = 27017
-	MongoDBKeyFileSecretSuffix        = "-key"
-	MongoDBExternalClientSecretSuffix = "-client-cert"
-	MongoDBExporterClientSecretSuffix = "-exporter-cert"
-	MongoDBServerSecretSuffix         = "-server-cert"
-	MongoDBPEMSecretSuffix            = "-pem"
+	MongoDBKeyFileSecretSuffix        = "key"
+	MongoDBExternalClientSecretSuffix = "client-cert"
+	MongoDBExporterClientSecretSuffix = "exporter-cert"
+	MongoDBServerSecretSuffix         = "server-cert"
+	MongoDBPEMSecretSuffix            = "pem"
 	MongoDBClientCertOrganization     = DatabaseNamePrefix + ":client"
 	MongoDBCertificateCN              = "root"
 
@@ -104,9 +104,9 @@ const (
 	RedisNodePort   = 6379
 	RedisGossipPort = 16379
 
-	PgBouncerServingClientSuffix      = "-serving-client-cert"
-	PgBouncerExporterClientCertSuffix = "-exporter-cert"
-	PgBouncerServingServerSuffix      = "-serving-server-cert"
+	PgBouncerServingClientSuffix      = "serving-client-cert"
+	PgBouncerExporterClientCertSuffix = "exporter-cert"
+	PgBouncerServingServerSuffix      = "serving-server-cert"
 	PgBouncerUpstreamServerCA         = "upstream-server-ca.crt"
 
 	MySQLClientCertSuffix         = "client-cert"


### PR DESCRIPTION
This is unnecessary for meta_util.ValidNames() helpers

Signed-off-by: Tamal Saha <tamal@appscode.com>