### PR TITLE
Keep resource request & limit is in sync

### DIFF
--- a/apis/kubedb/v1alpha2/constants.go
+++ b/apis/kubedb/v1alpha2/constants.go
@@ -287,7 +287,7 @@ const (
 )
 
 var (
-	defaultResourceLimits = core.ResourceList{
+	DefaultResourceLimits = core.ResourceList{
 		core.ResourceCPU:    resource.MustParse(".500"),
 		core.ResourceMemory: resource.MustParse("1024Mi"),
 	}

--- a/apis/kubedb/v1alpha2/elasticsearch_helpers.go
+++ b/apis/kubedb/v1alpha2/elasticsearch_helpers.go
@@ -299,21 +299,21 @@ func (e *Elasticsearch) SetDefaults(esVersion *v1alpha1.ElasticsearchVersion, to
 		if e.Spec.Topology.Ingest.Suffix == "" {
 			e.Spec.Topology.Ingest.Suffix = ElasticsearchIngestNodeSuffix
 		}
-		setDefaultResourceLimits(&e.Spec.Topology.Ingest.Resources, defaultResourceLimits, defaultResourceLimits)
+		SetDefaultResourceLimits(&e.Spec.Topology.Ingest.Resources, DefaultResourceLimits)
 
 		// Default to "data"
 		if e.Spec.Topology.Data.Suffix == "" {
 			e.Spec.Topology.Data.Suffix = ElasticsearchDataNodeSuffix
 		}
-		setDefaultResourceLimits(&e.Spec.Topology.Data.Resources, defaultResourceLimits, defaultResourceLimits)
+		SetDefaultResourceLimits(&e.Spec.Topology.Data.Resources, DefaultResourceLimits)
 
 		// Default to "master"
 		if e.Spec.Topology.Master.Suffix == "" {
 			e.Spec.Topology.Master.Suffix = ElasticsearchMasterNodeSuffix
 		}
-		setDefaultResourceLimits(&e.Spec.Topology.Master.Resources, defaultResourceLimits, defaultResourceLimits)
+		SetDefaultResourceLimits(&e.Spec.Topology.Master.Resources, DefaultResourceLimits)
 	} else {
-		setDefaultResourceLimits(&e.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
+		SetDefaultResourceLimits(&e.Spec.PodTemplate.Spec.Resources, DefaultResourceLimits)
 	}
 
 	// set default kernel settings

--- a/apis/kubedb/v1alpha2/etcd_helpers.go
+++ b/apis/kubedb/v1alpha2/etcd_helpers.go
@@ -155,7 +155,7 @@ func (e *Etcd) SetDefaults() {
 	}
 
 	e.Spec.Monitor.SetDefaults()
-	setDefaultResourceLimits(&e.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
+	SetDefaultResourceLimits(&e.Spec.PodTemplate.Spec.Resources, DefaultResourceLimits)
 }
 
 func (e *EtcdSpec) GetPersistentSecrets() []string {

--- a/apis/kubedb/v1alpha2/helpers.go
+++ b/apis/kubedb/v1alpha2/helpers.go
@@ -63,17 +63,28 @@ func GetServiceTemplate(templates []NamedServiceTemplateSpec, alias ServiceAlias
 	return ofst.ServiceTemplateSpec{}
 }
 
-func setDefaultResourceLimits(req *core.ResourceRequirements, limits, requests core.ResourceList) {
+func setDefaultResourceLimits(req *core.ResourceRequirements, defaultLimits, defaultRequests core.ResourceList) {
+	// if both request & limit is empty, return default
+	// if request is set,
+	//		- limit set:
+	//			- return max(limit,request)
+	//		- limit not set:
+	//			- return request
+	// else request is not set:
+	// 		- limit set:
+	//			- return limit
+	// 		- limit not set:
+	//			- return default
 	fn := func(name core.ResourceName, defaultValue resource.Quantity) resource.Quantity {
-		if req.Limits != nil {
-			if v, ok := req.Limits[name]; ok {
-				return v
+		if r, ok := req.Requests[name]; ok {
+			// l is greater than r == 1.
+			if l, exist := req.Limits[name]; exist && l.Cmp(r) == 1 {
+				return l
 			}
+			return r
 		}
-		if req.Requests != nil {
-			if v, ok := req.Requests[name]; ok {
-				return v
-			}
+		if l, ok := req.Limits[name]; ok {
+			return l
 		}
 		return defaultValue
 	}
@@ -84,10 +95,16 @@ func setDefaultResourceLimits(req *core.ResourceRequirements, limits, requests c
 	if req.Requests == nil {
 		req.Requests = core.ResourceList{}
 	}
-	for resource := range limits {
-		req.Limits[resource] = fn(resource, limits[resource])
-		if _, ok := req.Requests[resource]; !ok {
-			req.Requests[resource] = requests[resource]
+
+	// for: cpu & memory
+	//		- calculate limit
+	//		- if request not set
+	//			- same as limit
+	for resourceName := range defaultLimits {
+		req.Limits[resourceName] = fn(resourceName, defaultLimits[resourceName])
+
+		if _, ok := req.Requests[resourceName]; !ok {
+			req.Requests[resourceName] = req.Limits[resourceName]
 		}
 	}
 }

--- a/apis/kubedb/v1alpha2/helpers.go
+++ b/apis/kubedb/v1alpha2/helpers.go
@@ -99,12 +99,18 @@ func setDefaultResourceLimits(req *core.ResourceRequirements, defaultLimits, def
 	// for: cpu & memory
 	//		- calculate limit
 	//		- if request not set
-	//			- same as limit
+	//			- return min(defaultRequest, limit)
 	for resourceName := range defaultLimits {
 		req.Limits[resourceName] = fn(resourceName, defaultLimits[resourceName])
 
 		if _, ok := req.Requests[resourceName]; !ok {
-			req.Requests[resourceName] = req.Limits[resourceName]
+			// considering values always exist
+			req.Requests[resourceName] = defaultRequests[resourceName]
+			l := req.Limits[resourceName]
+			// l is less than default request
+			if l.Cmp(req.Requests[resourceName]) == -1 {
+				req.Requests[resourceName] = l
+			}
 		}
 	}
 }

--- a/apis/kubedb/v1alpha2/mariadb_helpers.go
+++ b/apis/kubedb/v1alpha2/mariadb_helpers.go
@@ -172,7 +172,7 @@ func (m *MariaDB) SetDefaults() {
 
 	m.Spec.setDefaultProbes()
 	m.Spec.Monitor.SetDefaults()
-	setDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
+	SetDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, DefaultResourceLimits)
 }
 
 func (m *MariaDBSpec) setDefaultProbes() {

--- a/apis/kubedb/v1alpha2/memcached_helpers.go
+++ b/apis/kubedb/v1alpha2/memcached_helpers.go
@@ -152,7 +152,7 @@ func (m *Memcached) SetDefaults() {
 	}
 
 	m.Spec.Monitor.SetDefaults()
-	setDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
+	SetDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, DefaultResourceLimits)
 }
 
 func (m *MemcachedSpec) GetPersistentSecrets() []string {

--- a/apis/kubedb/v1alpha2/mongodb_helpers.go
+++ b/apis/kubedb/v1alpha2/mongodb_helpers.go
@@ -365,9 +365,9 @@ func (m *MongoDB) SetDefaults(mgVersion *v1alpha1.MongoDBVersion, topology *core
 	}
 
 	if m.Spec.ShardTopology != nil {
-		setDefaultResourceLimits(&m.Spec.ShardTopology.Mongos.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
-		setDefaultResourceLimits(&m.Spec.ShardTopology.Shard.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
-		setDefaultResourceLimits(&m.Spec.ShardTopology.ConfigServer.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
+		SetDefaultResourceLimits(&m.Spec.ShardTopology.Mongos.PodTemplate.Spec.Resources, DefaultResourceLimits)
+		SetDefaultResourceLimits(&m.Spec.ShardTopology.Shard.PodTemplate.Spec.Resources, DefaultResourceLimits)
+		SetDefaultResourceLimits(&m.Spec.ShardTopology.ConfigServer.PodTemplate.Spec.Resources, DefaultResourceLimits)
 
 		if m.Spec.ShardTopology.Mongos.PodTemplate.Spec.Lifecycle == nil {
 			m.Spec.ShardTopology.Mongos.PodTemplate.Spec.Lifecycle = new(core.Lifecycle)
@@ -427,7 +427,7 @@ func (m *MongoDB) SetDefaults(mgVersion *v1alpha1.MongoDBVersion, topology *core
 		// set default affinity (PodAntiAffinity)
 		m.setDefaultAffinity(m.Spec.PodTemplate, m.OffshootSelectors(), topology)
 
-		setDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
+		SetDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, DefaultResourceLimits)
 	}
 
 	m.SetTLSDefaults()

--- a/apis/kubedb/v1alpha2/mysql_helpers.go
+++ b/apis/kubedb/v1alpha2/mysql_helpers.go
@@ -205,7 +205,7 @@ func (m *MySQL) SetDefaults(topology *core_util.Topology) {
 
 	m.setDefaultAffinity(&m.Spec.PodTemplate, m.OffshootSelectors(), topology)
 	m.SetTLSDefaults()
-	setDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
+	SetDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, DefaultResourceLimits)
 }
 
 // setDefaultAffinity

--- a/apis/kubedb/v1alpha2/perconaxtradb_helpers.go
+++ b/apis/kubedb/v1alpha2/perconaxtradb_helpers.go
@@ -173,7 +173,7 @@ func (p *PerconaXtraDB) SetDefaults() {
 
 	p.Spec.setDefaultProbes()
 	p.Spec.Monitor.SetDefaults()
-	setDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
+	SetDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, DefaultResourceLimits)
 }
 
 // setDefaultProbes sets defaults only when probe fields are nil.

--- a/apis/kubedb/v1alpha2/pgbouncer_helpers.go
+++ b/apis/kubedb/v1alpha2/pgbouncer_helpers.go
@@ -157,7 +157,7 @@ func (p *PgBouncer) SetDefaults() {
 	p.Spec.Monitor.SetDefaults()
 
 	p.SetTLSDefaults()
-	setDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
+	SetDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, DefaultResourceLimits)
 }
 
 func (p *PgBouncer) SetTLSDefaults() {

--- a/apis/kubedb/v1alpha2/postgres_helpers.go
+++ b/apis/kubedb/v1alpha2/postgres_helpers.go
@@ -183,7 +183,7 @@ func (p *Postgres) SetDefaults(topology *core_util.Topology) {
 
 	p.setDefaultAffinity(&p.Spec.PodTemplate, p.OffshootSelectors(), topology)
 	p.Spec.Monitor.SetDefaults()
-	setDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
+	SetDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, DefaultResourceLimits)
 }
 
 // setDefaultAffinity

--- a/apis/kubedb/v1alpha2/proxysql_helpers.go
+++ b/apis/kubedb/v1alpha2/proxysql_helpers.go
@@ -153,7 +153,7 @@ func (p *ProxySQL) SetDefaults() {
 	}
 
 	p.Spec.Monitor.SetDefaults()
-	setDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
+	SetDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, DefaultResourceLimits)
 }
 
 func (p *ProxySQLSpec) GetPersistentSecrets() []string {

--- a/apis/kubedb/v1alpha2/redis_helpers.go
+++ b/apis/kubedb/v1alpha2/redis_helpers.go
@@ -202,7 +202,7 @@ func (r *Redis) SetDefaults(topology *core_util.Topology) {
 	r.Spec.Monitor.SetDefaults()
 
 	r.SetTLSDefaults()
-	setDefaultResourceLimits(&r.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
+	SetDefaultResourceLimits(&r.Spec.PodTemplate.Spec.Resources, DefaultResourceLimits)
 }
 
 func (r *Redis) SetTLSDefaults() {


### PR DESCRIPTION
For handling cases like:

1.
```
      resources:
        requests:
          cpu: 400m
          memory: 600Mi
```
2.
```
      resources:
        limits:
          cpu: 750m
          memory: 800Mi
```

When 1 is updated with 2, resulted as below:

```
        resources:
          limits:
            cpu: 750m
            memory: 800Mi
          requests:
            cpu: 500m
            memory: 1Gi

```