### PR TITLE
MongoDB: Remove `OrganizationalUnit` and default `Organization`

### DIFF
--- a/apis/kubedb/v1alpha2/mongodb_helpers.go
+++ b/apis/kubedb/v1alpha2/mongodb_helpers.go
@@ -438,44 +438,64 @@ func (m *MongoDB) SetTLSDefaults() {
 		return
 	}
 
+	defaultServerOrg := []string{KubeDBOrganization}
 	if m.Spec.ShardTopology != nil {
+		_, cert := kmapi.GetCertificate(m.Spec.TLS.Certificates, string(MongoDBServerCert))
+		if cert != nil && cert.Subject != nil && cert.Subject.Organizations != nil {
+			defaultServerOrg = []string{}
+		}
+
 		m.Spec.TLS.Certificates = kmapi.SetMissingSpecForCertificate(m.Spec.TLS.Certificates, kmapi.CertificateSpec{
 			Alias:      string(MongoDBServerCert),
 			SecretName: "",
 			Subject: &kmapi.X509Subject{
-				Organizations:       []string{KubeDBOrganization},
-				OrganizationalUnits: []string{string(MongoDBServerCert)},
+				Organizations: defaultServerOrg,
 			},
 		})
+
 		// reset secret name to empty string, since multiple secrets will be created for each StatefulSet.
 		m.Spec.TLS.Certificates = kmapi.SetSecretNameForCertificate(m.Spec.TLS.Certificates, string(MongoDBServerCert), "")
 	} else {
+		_, cert := kmapi.GetCertificate(m.Spec.TLS.Certificates, string(MongoDBServerCert))
+		if cert != nil && cert.Subject != nil && cert.Subject.Organizations != nil {
+			defaultServerOrg = []string{}
+		}
 		m.Spec.TLS.Certificates = kmapi.SetMissingSpecForCertificate(m.Spec.TLS.Certificates, kmapi.CertificateSpec{
 			Alias:      string(MongoDBServerCert),
 			SecretName: m.CertificateName(MongoDBServerCert, ""),
 			Subject: &kmapi.X509Subject{
-				Organizations:       []string{KubeDBOrganization},
-				OrganizationalUnits: []string{string(MongoDBServerCert)},
+				Organizations: defaultServerOrg,
 			},
 		})
+	}
+
+	defaultClientOrg := []string{KubeDBOrganization}
+	_, cert := kmapi.GetCertificate(m.Spec.TLS.Certificates, string(MongoDBClientCert))
+	if cert != nil && cert.Subject != nil && cert.Subject.Organizations != nil {
+		defaultClientOrg = []string{}
 	}
 	m.Spec.TLS.Certificates = kmapi.SetMissingSpecForCertificate(m.Spec.TLS.Certificates, kmapi.CertificateSpec{
 		Alias:      string(MongoDBClientCert),
 		SecretName: m.CertificateName(MongoDBClientCert, ""),
 		Subject: &kmapi.X509Subject{
-			Organizations:       []string{KubeDBOrganization},
-			OrganizationalUnits: []string{string(MongoDBClientCert)},
+			Organizations: defaultClientOrg,
 		},
 	})
+
+	defaultExporterOrg := []string{KubeDBOrganization}
+	_, cert = kmapi.GetCertificate(m.Spec.TLS.Certificates, string(MongoDBMetricsExporterCert))
+	if cert != nil && cert.Subject != nil && cert.Subject.Organizations != nil {
+		defaultExporterOrg = []string{}
+	}
 	m.Spec.TLS.Certificates = kmapi.SetMissingSpecForCertificate(m.Spec.TLS.Certificates, kmapi.CertificateSpec{
 		Alias:      string(MongoDBMetricsExporterCert),
 		SecretName: m.CertificateName(MongoDBMetricsExporterCert, ""),
 		Subject: &kmapi.X509Subject{
-			Organizations:       []string{KubeDBOrganization},
-			OrganizationalUnits: []string{string(MongoDBMetricsExporterCert)},
+			Organizations: defaultExporterOrg,
 		},
 	})
 }
+
 func (m *MongoDB) getCmdForProbes(mgVersion *v1alpha1.MongoDBVersion) []string {
 	var sslArgs string
 	if m.Spec.SSLMode == SSLModeRequireSSL {

--- a/apis/kubedb/v1alpha2/mongodb_helpers.go
+++ b/apis/kubedb/v1alpha2/mongodb_helpers.go
@@ -442,7 +442,7 @@ func (m *MongoDB) SetTLSDefaults() {
 	if m.Spec.ShardTopology != nil {
 		_, cert := kmapi.GetCertificate(m.Spec.TLS.Certificates, string(MongoDBServerCert))
 		if cert != nil && cert.Subject != nil && cert.Subject.Organizations != nil {
-			defaultServerOrg = []string{}
+			defaultServerOrg = cert.Subject.Organizations
 		}
 
 		m.Spec.TLS.Certificates = kmapi.SetMissingSpecForCertificate(m.Spec.TLS.Certificates, kmapi.CertificateSpec{
@@ -458,7 +458,7 @@ func (m *MongoDB) SetTLSDefaults() {
 	} else {
 		_, cert := kmapi.GetCertificate(m.Spec.TLS.Certificates, string(MongoDBServerCert))
 		if cert != nil && cert.Subject != nil && cert.Subject.Organizations != nil {
-			defaultServerOrg = []string{}
+			defaultServerOrg = cert.Subject.Organizations
 		}
 		m.Spec.TLS.Certificates = kmapi.SetMissingSpecForCertificate(m.Spec.TLS.Certificates, kmapi.CertificateSpec{
 			Alias:      string(MongoDBServerCert),
@@ -472,7 +472,7 @@ func (m *MongoDB) SetTLSDefaults() {
 	defaultClientOrg := []string{KubeDBOrganization}
 	_, cert := kmapi.GetCertificate(m.Spec.TLS.Certificates, string(MongoDBClientCert))
 	if cert != nil && cert.Subject != nil && cert.Subject.Organizations != nil {
-		defaultClientOrg = []string{}
+		defaultClientOrg = cert.Subject.Organizations
 	}
 	m.Spec.TLS.Certificates = kmapi.SetMissingSpecForCertificate(m.Spec.TLS.Certificates, kmapi.CertificateSpec{
 		Alias:      string(MongoDBClientCert),
@@ -485,7 +485,7 @@ func (m *MongoDB) SetTLSDefaults() {
 	defaultExporterOrg := []string{KubeDBOrganization}
 	_, cert = kmapi.GetCertificate(m.Spec.TLS.Certificates, string(MongoDBMetricsExporterCert))
 	if cert != nil && cert.Subject != nil && cert.Subject.Organizations != nil {
-		defaultExporterOrg = []string{}
+		defaultExporterOrg = cert.Subject.Organizations
 	}
 	m.Spec.TLS.Certificates = kmapi.SetMissingSpecForCertificate(m.Spec.TLS.Certificates, kmapi.CertificateSpec{
 		Alias:      string(MongoDBMetricsExporterCert),


### PR DESCRIPTION

Signed-off-by: Mohammad Fahim Abrar <fahimabrar@appscode.com>