### PR TITLE
Use etcd ports for for pg coordinator

### DIFF
--- a/apis/kubedb/v1alpha2/constants.go
+++ b/apis/kubedb/v1alpha2/constants.go
@@ -209,10 +209,10 @@ const (
 	PostgresLabelRole              = kubedb.GroupName + "/role"
 
 	PostgresCoordinatorContainerName = "pg-coordinator"
-	PostgresCoordinatorPort          = 12345
+	PostgresCoordinatorPort          = 2380
 	PostgresCoordinatorPortName      = "coordinator"
 
-	PostgresCoordinatorClientPort     = 12380
+	PostgresCoordinatorClientPort     = 2379
 	PostgresCoordinatorClientPortName = "coordinatclient"
 
 	PostgresRunScriptMountPath  = "/run_scripts"


### PR DESCRIPTION
fix: updated pg-coordinator port 12345 with 2380
fix: updated pg-coordinator client 12380 port with 2379
