### PR TITLE
Add separate Security Config Directory constant for Opensearch V2

### DIFF
--- a/apis/kubedb/v1alpha2/constants.go
+++ b/apis/kubedb/v1alpha2/constants.go
@@ -86,6 +86,7 @@ const (
 	ElasticsearchTempDir                         = "/tmp"
 	ElasticsearchOpendistroSecurityConfigDir     = "/usr/share/elasticsearch/plugins/opendistro_security/securityconfig"
 	ElasticsearchOpenSearchSecurityConfigDir     = "/usr/share/opensearch/plugins/opensearch-security/securityconfig"
+	ElasticsearchOpenSearchSecurityConfigDirV2   = "/usr/share/opensearch/config/opensearch-security"
 	ElasticsearchSearchGuardSecurityConfigDir    = "/usr/share/elasticsearch/plugins/search-guard-%v/sgconfig"
 	ElasticsearchOpendistroReadallMonitorRole    = "readall_and_monitor"
 	ElasticsearchOpenSearchReadallMonitorRole    = "readall_and_monitor"


### PR DESCRIPTION
Opensearch v2 uses a separate security config directory compared to V1. An init container is used to merge the default security config files to Opensearch db container. 