### PR TITLE
Remove spec.upgrade field and Upgrade ops type

### DIFF
--- a/apis/ops/v1alpha1/elasticsearch_ops_helpers.go
+++ b/apis/ops/v1alpha1/elasticsearch_ops_helpers.go
@@ -63,21 +63,6 @@ func (e *ElasticsearchOpsRequest) GetObjectMeta() metav1.ObjectMeta {
 	return e.ObjectMeta
 }
 
-func (e ElasticsearchOpsRequest) GetRequestType() any {
-	switch e.Spec.Type {
-	case ElasticsearchOpsRequestTypeUpgrade:
-		return ElasticsearchOpsRequestTypeUpdateVersion
-	}
-	return e.Spec.Type
-}
-
-func (e ElasticsearchOpsRequest) GetUpdateVersionSpec() *ElasticsearchUpdateVersionSpec {
-	if e.Spec.UpdateVersion != nil {
-		return e.Spec.UpdateVersion
-	}
-	return e.Spec.Upgrade
-}
-
 func (e *ElasticsearchOpsRequest) GetDBRefName() string {
 	return e.Spec.DatabaseRef.Name
 }

--- a/apis/ops/v1alpha1/elasticsearch_ops_types.go
+++ b/apis/ops/v1alpha1/elasticsearch_ops_types.go
@@ -57,9 +57,6 @@ type ElasticsearchOpsRequestSpec struct {
 	Type ElasticsearchOpsRequestType `json:"type"`
 	// Specifies information necessary for upgrading Elasticsearch
 	UpdateVersion *ElasticsearchUpdateVersionSpec `json:"updateVersion,omitempty"`
-	// Specifies information necessary for upgrading Elasticsearch
-	// Deprecated: use UpdateVersion
-	Upgrade *ElasticsearchUpdateVersionSpec `json:"upgrade,omitempty"`
 	// Specifies information necessary for horizontal scaling
 	HorizontalScaling *ElasticsearchHorizontalScalingSpec `json:"horizontalScaling,omitempty"`
 	// Specifies information necessary for vertical scaling
@@ -80,7 +77,7 @@ type ElasticsearchOpsRequestSpec struct {
 }
 
 // +kubebuilder:validation:Enum=Upgrade;UpdateVersion;HorizontalScaling;VerticalScaling;VolumeExpansion;Restart;Reconfigure;ReconfigureTLS
-// ENUM(Upgrade, UpdateVersion, HorizontalScaling, VerticalScaling, VolumeExpansion, Restart, Reconfigure, ReconfigureTLS)
+// ENUM(UpdateVersion, HorizontalScaling, VerticalScaling, VolumeExpansion, Restart, Reconfigure, ReconfigureTLS)
 type ElasticsearchOpsRequestType string
 
 // ElasticsearchReplicaReadinessCriteria is the criteria for checking readiness of an Elasticsearch database

--- a/apis/ops/v1alpha1/elasticsearch_ops_types_enum.go
+++ b/apis/ops/v1alpha1/elasticsearch_ops_types_enum.go
@@ -12,8 +12,6 @@ import (
 )
 
 const (
-	// ElasticsearchOpsRequestTypeUpgrade is a ElasticsearchOpsRequestType of type Upgrade.
-	ElasticsearchOpsRequestTypeUpgrade ElasticsearchOpsRequestType = "Upgrade"
 	// ElasticsearchOpsRequestTypeUpdateVersion is a ElasticsearchOpsRequestType of type UpdateVersion.
 	ElasticsearchOpsRequestTypeUpdateVersion ElasticsearchOpsRequestType = "UpdateVersion"
 	// ElasticsearchOpsRequestTypeHorizontalScaling is a ElasticsearchOpsRequestType of type HorizontalScaling.
@@ -33,7 +31,6 @@ const (
 var ErrInvalidElasticsearchOpsRequestType = fmt.Errorf("not a valid ElasticsearchOpsRequestType, try [%s]", strings.Join(_ElasticsearchOpsRequestTypeNames, ", "))
 
 var _ElasticsearchOpsRequestTypeNames = []string{
-	string(ElasticsearchOpsRequestTypeUpgrade),
 	string(ElasticsearchOpsRequestTypeUpdateVersion),
 	string(ElasticsearchOpsRequestTypeHorizontalScaling),
 	string(ElasticsearchOpsRequestTypeVerticalScaling),
@@ -53,7 +50,6 @@ func ElasticsearchOpsRequestTypeNames() []string {
 // ElasticsearchOpsRequestTypeValues returns a list of the values for ElasticsearchOpsRequestType
 func ElasticsearchOpsRequestTypeValues() []ElasticsearchOpsRequestType {
 	return []ElasticsearchOpsRequestType{
-		ElasticsearchOpsRequestTypeUpgrade,
 		ElasticsearchOpsRequestTypeUpdateVersion,
 		ElasticsearchOpsRequestTypeHorizontalScaling,
 		ElasticsearchOpsRequestTypeVerticalScaling,
@@ -77,7 +73,6 @@ func (x ElasticsearchOpsRequestType) IsValid() bool {
 }
 
 var _ElasticsearchOpsRequestTypeValue = map[string]ElasticsearchOpsRequestType{
-	"Upgrade":           ElasticsearchOpsRequestTypeUpgrade,
 	"UpdateVersion":     ElasticsearchOpsRequestTypeUpdateVersion,
 	"HorizontalScaling": ElasticsearchOpsRequestTypeHorizontalScaling,
 	"VerticalScaling":   ElasticsearchOpsRequestTypeVerticalScaling,

--- a/apis/ops/v1alpha1/etcd_ops_helpers.go
+++ b/apis/ops/v1alpha1/etcd_ops_helpers.go
@@ -63,14 +63,6 @@ func (e *EtcdOpsRequest) GetObjectMeta() metav1.ObjectMeta {
 	return e.ObjectMeta
 }
 
-func (e EtcdOpsRequest) GetRequestType() any {
-	return e.Spec.Type
-}
-
-func (e EtcdOpsRequest) GetUpdateVersionSpec() *EtcdUpdateVersionSpec {
-	return e.Spec.UpdateVersion
-}
-
 func (e *EtcdOpsRequest) GetDBRefName() string {
 	return e.Spec.DatabaseRef.Name
 }

--- a/apis/ops/v1alpha1/kafka_ops_helpers.go
+++ b/apis/ops/v1alpha1/kafka_ops_helpers.go
@@ -55,16 +55,8 @@ func (k *KafkaOpsRequest) ResourcePlural() string {
 
 var _ Accessor = &KafkaOpsRequest{}
 
-func (k *KafkaOpsRequest) GetRequestType() any {
-	return k.Spec.Type
-}
-
 func (k *KafkaOpsRequest) GetObjectMeta() metav1.ObjectMeta {
 	return k.ObjectMeta
-}
-
-func (k *KafkaOpsRequest) GetUpdateVersionSpec() *KafkaUpdateVersionSpec {
-	return k.Spec.UpdateVersion
 }
 
 func (k *KafkaOpsRequest) GetDBRefName() string {

--- a/apis/ops/v1alpha1/mariadb_ops_helpers.go
+++ b/apis/ops/v1alpha1/mariadb_ops_helpers.go
@@ -84,21 +84,6 @@ func (m *MariaDBOpsRequest) GetObjectMeta() metav1.ObjectMeta {
 	return m.ObjectMeta
 }
 
-func (m MariaDBOpsRequest) GetRequestType() any {
-	switch m.Spec.Type {
-	case MariaDBOpsRequestTypeUpgrade:
-		return MariaDBOpsRequestTypeUpdateVersion
-	}
-	return m.Spec.Type
-}
-
-func (m MariaDBOpsRequest) GetUpdateVersionSpec() *MariaDBUpdateVersionSpec {
-	if m.Spec.UpdateVersion != nil {
-		return m.Spec.UpdateVersion
-	}
-	return m.Spec.Upgrade
-}
-
 func (m *MariaDBOpsRequest) GetDBRefName() string {
 	return m.Spec.DatabaseRef.Name
 }

--- a/apis/ops/v1alpha1/mariadb_ops_types.go
+++ b/apis/ops/v1alpha1/mariadb_ops_types.go
@@ -57,9 +57,6 @@ type MariaDBOpsRequestSpec struct {
 	Type MariaDBOpsRequestType `json:"type"`
 	// Specifies information necessary for upgrading MariaDB
 	UpdateVersion *MariaDBUpdateVersionSpec `json:"updateVersion,omitempty"`
-	// Specifies information necessary for upgrading MariaDB
-	// Deprecated: use UpdateVersion
-	Upgrade *MariaDBUpdateVersionSpec `json:"upgrade,omitempty"`
 	// Specifies information necessary for horizontal scaling
 	HorizontalScaling *MariaDBHorizontalScalingSpec `json:"horizontalScaling,omitempty"`
 	// Specifies information necessary for vertical scaling
@@ -80,7 +77,7 @@ type MariaDBOpsRequestSpec struct {
 }
 
 // +kubebuilder:validation:Enum=Upgrade;UpdateVersion;HorizontalScaling;VerticalScaling;VolumeExpansion;Restart;Reconfigure;ReconfigureTLS
-// ENUM(Upgrade, UpdateVersion, HorizontalScaling, VerticalScaling, VolumeExpansion, Restart, Reconfigure, ReconfigureTLS)
+// ENUM(UpdateVersion, HorizontalScaling, VerticalScaling, VolumeExpansion, Restart, Reconfigure, ReconfigureTLS)
 type MariaDBOpsRequestType string
 
 // MariaDBReplicaReadinessCriteria is the criteria for checking readiness of an MariaDB database

--- a/apis/ops/v1alpha1/mariadb_ops_types_enum.go
+++ b/apis/ops/v1alpha1/mariadb_ops_types_enum.go
@@ -12,8 +12,6 @@ import (
 )
 
 const (
-	// MariaDBOpsRequestTypeUpgrade is a MariaDBOpsRequestType of type Upgrade.
-	MariaDBOpsRequestTypeUpgrade MariaDBOpsRequestType = "Upgrade"
 	// MariaDBOpsRequestTypeUpdateVersion is a MariaDBOpsRequestType of type UpdateVersion.
 	MariaDBOpsRequestTypeUpdateVersion MariaDBOpsRequestType = "UpdateVersion"
 	// MariaDBOpsRequestTypeHorizontalScaling is a MariaDBOpsRequestType of type HorizontalScaling.
@@ -33,7 +31,6 @@ const (
 var ErrInvalidMariaDBOpsRequestType = fmt.Errorf("not a valid MariaDBOpsRequestType, try [%s]", strings.Join(_MariaDBOpsRequestTypeNames, ", "))
 
 var _MariaDBOpsRequestTypeNames = []string{
-	string(MariaDBOpsRequestTypeUpgrade),
 	string(MariaDBOpsRequestTypeUpdateVersion),
 	string(MariaDBOpsRequestTypeHorizontalScaling),
 	string(MariaDBOpsRequestTypeVerticalScaling),
@@ -53,7 +50,6 @@ func MariaDBOpsRequestTypeNames() []string {
 // MariaDBOpsRequestTypeValues returns a list of the values for MariaDBOpsRequestType
 func MariaDBOpsRequestTypeValues() []MariaDBOpsRequestType {
 	return []MariaDBOpsRequestType{
-		MariaDBOpsRequestTypeUpgrade,
 		MariaDBOpsRequestTypeUpdateVersion,
 		MariaDBOpsRequestTypeHorizontalScaling,
 		MariaDBOpsRequestTypeVerticalScaling,
@@ -77,7 +73,6 @@ func (x MariaDBOpsRequestType) IsValid() bool {
 }
 
 var _MariaDBOpsRequestTypeValue = map[string]MariaDBOpsRequestType{
-	"Upgrade":           MariaDBOpsRequestTypeUpgrade,
 	"UpdateVersion":     MariaDBOpsRequestTypeUpdateVersion,
 	"HorizontalScaling": MariaDBOpsRequestTypeHorizontalScaling,
 	"VerticalScaling":   MariaDBOpsRequestTypeVerticalScaling,

--- a/apis/ops/v1alpha1/memcached_ops_helpers.go
+++ b/apis/ops/v1alpha1/memcached_ops_helpers.go
@@ -63,21 +63,6 @@ func (m *MemcachedOpsRequest) GetObjectMeta() metav1.ObjectMeta {
 	return m.ObjectMeta
 }
 
-func (m MemcachedOpsRequest) GetRequestType() any {
-	switch m.Spec.Type {
-	case MemcachedOpsRequestTypeUpgrade:
-		return MemcachedOpsRequestTypeUpdateVersion
-	}
-	return m.Spec.Type
-}
-
-func (m MemcachedOpsRequest) GetUpdateVersionSpec() *MemcachedUpdateVersionSpec {
-	if m.Spec.UpdateVersion != nil {
-		return m.Spec.UpdateVersion
-	}
-	return m.Spec.Upgrade
-}
-
 func (m *MemcachedOpsRequest) GetDBRefName() string {
 	return m.Spec.DatabaseRef.Name
 }

--- a/apis/ops/v1alpha1/memcached_ops_types.go
+++ b/apis/ops/v1alpha1/memcached_ops_types.go
@@ -56,9 +56,6 @@ type MemcachedOpsRequestSpec struct {
 	Type MemcachedOpsRequestType `json:"type"`
 	// Specifies information necessary for upgrading Memcached
 	UpdateVersion *MemcachedUpdateVersionSpec `json:"updateVersion,omitempty"`
-	// Specifies information necessary for upgrading Memcached
-	// Deprecated: use UpdateVersion
-	Upgrade *MemcachedUpdateVersionSpec `json:"upgrade,omitempty"`
 	// Specifies information necessary for horizontal scaling
 	HorizontalScaling *MemcachedHorizontalScalingSpec `json:"horizontalScaling,omitempty"`
 	// Specifies information necessary for vertical scaling
@@ -77,7 +74,7 @@ type MemcachedOpsRequestSpec struct {
 }
 
 // +kubebuilder:validation:Enum=Upgrade;UpdateVersion;HorizontalScaling;VerticalScaling;VolumeExpansion;Restart;Reconfigure;ReconfigureTLS
-// ENUM(Upgrade, UpdateVersion, HorizontalScaling, VerticalScaling, VolumeExpansion, Restart, Reconfigure, ReconfigureTLS)
+// ENUM(UpdateVersion, HorizontalScaling, VerticalScaling, VolumeExpansion, Restart, Reconfigure, ReconfigureTLS)
 type MemcachedOpsRequestType string
 
 // MemcachedReplicaReadinessCriteria is the criteria for checking readiness of a Memcached pod

--- a/apis/ops/v1alpha1/memcached_ops_types_enum.go
+++ b/apis/ops/v1alpha1/memcached_ops_types_enum.go
@@ -12,8 +12,6 @@ import (
 )
 
 const (
-	// MemcachedOpsRequestTypeUpgrade is a MemcachedOpsRequestType of type Upgrade.
-	MemcachedOpsRequestTypeUpgrade MemcachedOpsRequestType = "Upgrade"
 	// MemcachedOpsRequestTypeUpdateVersion is a MemcachedOpsRequestType of type UpdateVersion.
 	MemcachedOpsRequestTypeUpdateVersion MemcachedOpsRequestType = "UpdateVersion"
 	// MemcachedOpsRequestTypeHorizontalScaling is a MemcachedOpsRequestType of type HorizontalScaling.
@@ -33,7 +31,6 @@ const (
 var ErrInvalidMemcachedOpsRequestType = fmt.Errorf("not a valid MemcachedOpsRequestType, try [%s]", strings.Join(_MemcachedOpsRequestTypeNames, ", "))
 
 var _MemcachedOpsRequestTypeNames = []string{
-	string(MemcachedOpsRequestTypeUpgrade),
 	string(MemcachedOpsRequestTypeUpdateVersion),
 	string(MemcachedOpsRequestTypeHorizontalScaling),
 	string(MemcachedOpsRequestTypeVerticalScaling),
@@ -53,7 +50,6 @@ func MemcachedOpsRequestTypeNames() []string {
 // MemcachedOpsRequestTypeValues returns a list of the values for MemcachedOpsRequestType
 func MemcachedOpsRequestTypeValues() []MemcachedOpsRequestType {
 	return []MemcachedOpsRequestType{
-		MemcachedOpsRequestTypeUpgrade,
 		MemcachedOpsRequestTypeUpdateVersion,
 		MemcachedOpsRequestTypeHorizontalScaling,
 		MemcachedOpsRequestTypeVerticalScaling,
@@ -77,7 +73,6 @@ func (x MemcachedOpsRequestType) IsValid() bool {
 }
 
 var _MemcachedOpsRequestTypeValue = map[string]MemcachedOpsRequestType{
-	"Upgrade":           MemcachedOpsRequestTypeUpgrade,
 	"UpdateVersion":     MemcachedOpsRequestTypeUpdateVersion,
 	"HorizontalScaling": MemcachedOpsRequestTypeHorizontalScaling,
 	"VerticalScaling":   MemcachedOpsRequestTypeVerticalScaling,

--- a/apis/ops/v1alpha1/mongodb_ops_helpers.go
+++ b/apis/ops/v1alpha1/mongodb_ops_helpers.go
@@ -63,21 +63,6 @@ func (m *MongoDBOpsRequest) GetObjectMeta() metav1.ObjectMeta {
 	return m.ObjectMeta
 }
 
-func (m MongoDBOpsRequest) GetRequestType() any {
-	switch m.Spec.Type {
-	case MongoDBOpsRequestTypeUpgrade:
-		return MongoDBOpsRequestTypeUpdateVersion
-	}
-	return m.Spec.Type
-}
-
-func (m MongoDBOpsRequest) GetUpdateVersionSpec() *MongoDBUpdateVersionSpec {
-	if m.Spec.UpdateVersion != nil {
-		return m.Spec.UpdateVersion
-	}
-	return m.Spec.Upgrade
-}
-
 func (m *MongoDBOpsRequest) GetDBRefName() string {
 	return m.Spec.DatabaseRef.Name
 }

--- a/apis/ops/v1alpha1/mongodb_ops_types.go
+++ b/apis/ops/v1alpha1/mongodb_ops_types.go
@@ -57,9 +57,6 @@ type MongoDBOpsRequestSpec struct {
 	Type MongoDBOpsRequestType `json:"type"`
 	// Specifies information necessary for upgrading MongoDB
 	UpdateVersion *MongoDBUpdateVersionSpec `json:"updateVersion,omitempty"`
-	// Specifies information necessary for upgrading MongoDB
-	// Deprecated: use UpdateVersion
-	Upgrade *MongoDBUpdateVersionSpec `json:"upgrade,omitempty"`
 	// Specifies information necessary for horizontal scaling
 	HorizontalScaling *MongoDBHorizontalScalingSpec `json:"horizontalScaling,omitempty"`
 	// Specifies information necessary for vertical scaling
@@ -85,7 +82,7 @@ type MongoDBOpsRequestSpec struct {
 }
 
 // +kubebuilder:validation:Enum=Upgrade;UpdateVersion;HorizontalScaling;VerticalScaling;VolumeExpansion;Restart;Reconfigure;ReconfigureTLS;Reprovision
-// ENUM(Upgrade, UpdateVersion, HorizontalScaling, VerticalScaling, VolumeExpansion, Restart, Reconfigure, ReconfigureTLS, Reprovision)
+// ENUM(UpdateVersion, HorizontalScaling, VerticalScaling, VolumeExpansion, Restart, Reconfigure, ReconfigureTLS, Reprovision)
 type MongoDBOpsRequestType string
 
 // MongoDBReplicaReadinessCriteria is the criteria for checking readiness of a MongoDB pod

--- a/apis/ops/v1alpha1/mongodb_ops_types_enum.go
+++ b/apis/ops/v1alpha1/mongodb_ops_types_enum.go
@@ -12,8 +12,6 @@ import (
 )
 
 const (
-	// MongoDBOpsRequestTypeUpgrade is a MongoDBOpsRequestType of type Upgrade.
-	MongoDBOpsRequestTypeUpgrade MongoDBOpsRequestType = "Upgrade"
 	// MongoDBOpsRequestTypeUpdateVersion is a MongoDBOpsRequestType of type UpdateVersion.
 	MongoDBOpsRequestTypeUpdateVersion MongoDBOpsRequestType = "UpdateVersion"
 	// MongoDBOpsRequestTypeHorizontalScaling is a MongoDBOpsRequestType of type HorizontalScaling.
@@ -35,7 +33,6 @@ const (
 var ErrInvalidMongoDBOpsRequestType = fmt.Errorf("not a valid MongoDBOpsRequestType, try [%s]", strings.Join(_MongoDBOpsRequestTypeNames, ", "))
 
 var _MongoDBOpsRequestTypeNames = []string{
-	string(MongoDBOpsRequestTypeUpgrade),
 	string(MongoDBOpsRequestTypeUpdateVersion),
 	string(MongoDBOpsRequestTypeHorizontalScaling),
 	string(MongoDBOpsRequestTypeVerticalScaling),
@@ -56,7 +53,6 @@ func MongoDBOpsRequestTypeNames() []string {
 // MongoDBOpsRequestTypeValues returns a list of the values for MongoDBOpsRequestType
 func MongoDBOpsRequestTypeValues() []MongoDBOpsRequestType {
 	return []MongoDBOpsRequestType{
-		MongoDBOpsRequestTypeUpgrade,
 		MongoDBOpsRequestTypeUpdateVersion,
 		MongoDBOpsRequestTypeHorizontalScaling,
 		MongoDBOpsRequestTypeVerticalScaling,
@@ -81,7 +77,6 @@ func (x MongoDBOpsRequestType) IsValid() bool {
 }
 
 var _MongoDBOpsRequestTypeValue = map[string]MongoDBOpsRequestType{
-	"Upgrade":           MongoDBOpsRequestTypeUpgrade,
 	"UpdateVersion":     MongoDBOpsRequestTypeUpdateVersion,
 	"HorizontalScaling": MongoDBOpsRequestTypeHorizontalScaling,
 	"VerticalScaling":   MongoDBOpsRequestTypeVerticalScaling,

--- a/apis/ops/v1alpha1/mysql_ops_helpers.go
+++ b/apis/ops/v1alpha1/mysql_ops_helpers.go
@@ -64,21 +64,6 @@ func (m *MySQLOpsRequest) GetObjectMeta() metav1.ObjectMeta {
 	return m.ObjectMeta
 }
 
-func (m MySQLOpsRequest) GetRequestType() any {
-	switch m.Spec.Type {
-	case MySQLOpsRequestTypeUpgrade:
-		return MySQLOpsRequestTypeUpdateVersion
-	}
-	return m.Spec.Type
-}
-
-func (m MySQLOpsRequest) GetUpdateVersionSpec() *MySQLUpdateVersionSpec {
-	if m.Spec.UpdateVersion != nil {
-		return m.Spec.UpdateVersion
-	}
-	return m.Spec.Upgrade
-}
-
 func (m *MySQLOpsRequest) GetDBRefName() string {
 	return m.Spec.DatabaseRef.Name
 }

--- a/apis/ops/v1alpha1/mysql_ops_types.go
+++ b/apis/ops/v1alpha1/mysql_ops_types.go
@@ -57,9 +57,6 @@ type MySQLOpsRequestSpec struct {
 	Type MySQLOpsRequestType `json:"type"`
 	// Specifies information necessary for upgrading MySQL
 	UpdateVersion *MySQLUpdateVersionSpec `json:"updateVersion,omitempty"`
-	// Specifies information necessary for upgrading MySQL
-	// Deprecated: use UpdateVersion
-	Upgrade *MySQLUpdateVersionSpec `json:"upgrade,omitempty"`
 	// Specifies information necessary for horizontal scaling
 	HorizontalScaling *MySQLHorizontalScalingSpec `json:"horizontalScaling,omitempty"`
 	// Specifies information necessary for vertical scaling
@@ -80,7 +77,7 @@ type MySQLOpsRequestSpec struct {
 }
 
 // +kubebuilder:validation:Enum=Upgrade;UpdateVersion;HorizontalScaling;VerticalScaling;VolumeExpansion;Restart;Reconfigure;ReconfigureTLS
-// ENUM(Upgrade, UpdateVersion, HorizontalScaling, VerticalScaling, VolumeExpansion, Restart, Reconfigure, ReconfigureTLS)
+// ENUM(UpdateVersion, HorizontalScaling, VerticalScaling, VolumeExpansion, Restart, Reconfigure, ReconfigureTLS)
 type MySQLOpsRequestType string
 
 // MySQLReplicaReadinessCriteria is the criteria for checking readiness of a MySQL pod

--- a/apis/ops/v1alpha1/mysql_ops_types_enum.go
+++ b/apis/ops/v1alpha1/mysql_ops_types_enum.go
@@ -12,8 +12,6 @@ import (
 )
 
 const (
-	// MySQLOpsRequestTypeUpgrade is a MySQLOpsRequestType of type Upgrade.
-	MySQLOpsRequestTypeUpgrade MySQLOpsRequestType = "Upgrade"
 	// MySQLOpsRequestTypeUpdateVersion is a MySQLOpsRequestType of type UpdateVersion.
 	MySQLOpsRequestTypeUpdateVersion MySQLOpsRequestType = "UpdateVersion"
 	// MySQLOpsRequestTypeHorizontalScaling is a MySQLOpsRequestType of type HorizontalScaling.
@@ -33,7 +31,6 @@ const (
 var ErrInvalidMySQLOpsRequestType = fmt.Errorf("not a valid MySQLOpsRequestType, try [%s]", strings.Join(_MySQLOpsRequestTypeNames, ", "))
 
 var _MySQLOpsRequestTypeNames = []string{
-	string(MySQLOpsRequestTypeUpgrade),
 	string(MySQLOpsRequestTypeUpdateVersion),
 	string(MySQLOpsRequestTypeHorizontalScaling),
 	string(MySQLOpsRequestTypeVerticalScaling),
@@ -53,7 +50,6 @@ func MySQLOpsRequestTypeNames() []string {
 // MySQLOpsRequestTypeValues returns a list of the values for MySQLOpsRequestType
 func MySQLOpsRequestTypeValues() []MySQLOpsRequestType {
 	return []MySQLOpsRequestType{
-		MySQLOpsRequestTypeUpgrade,
 		MySQLOpsRequestTypeUpdateVersion,
 		MySQLOpsRequestTypeHorizontalScaling,
 		MySQLOpsRequestTypeVerticalScaling,
@@ -77,7 +73,6 @@ func (x MySQLOpsRequestType) IsValid() bool {
 }
 
 var _MySQLOpsRequestTypeValue = map[string]MySQLOpsRequestType{
-	"Upgrade":           MySQLOpsRequestTypeUpgrade,
 	"UpdateVersion":     MySQLOpsRequestTypeUpdateVersion,
 	"HorizontalScaling": MySQLOpsRequestTypeHorizontalScaling,
 	"VerticalScaling":   MySQLOpsRequestTypeVerticalScaling,

--- a/apis/ops/v1alpha1/openapi_generated.go
+++ b/apis/ops/v1alpha1/openapi_generated.go
@@ -22370,12 +22370,6 @@ func schema_apimachinery_apis_ops_v1alpha1_ElasticsearchOpsRequestSpec(ref commo
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.ElasticsearchUpdateVersionSpec"),
 						},
 					},
-					"upgrade": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Specifies information necessary for upgrading Elasticsearch Deprecated: use UpdateVersion",
-							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.ElasticsearchUpdateVersionSpec"),
-						},
-					},
 					"horizontalScaling": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specifies information necessary for horizontal scaling",
@@ -23658,12 +23652,6 @@ func schema_apimachinery_apis_ops_v1alpha1_MariaDBOpsRequestSpec(ref common.Refe
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.MariaDBUpdateVersionSpec"),
 						},
 					},
-					"upgrade": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Specifies information necessary for upgrading MariaDB Deprecated: use UpdateVersion",
-							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.MariaDBUpdateVersionSpec"),
-						},
-					},
 					"horizontalScaling": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specifies information necessary for horizontal scaling",
@@ -24046,12 +24034,6 @@ func schema_apimachinery_apis_ops_v1alpha1_MemcachedOpsRequestSpec(ref common.Re
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.MemcachedUpdateVersionSpec"),
 						},
 					},
-					"upgrade": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Specifies information necessary for upgrading Memcached Deprecated: use UpdateVersion",
-							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.MemcachedUpdateVersionSpec"),
-						},
-					},
 					"horizontalScaling": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specifies information necessary for horizontal scaling",
@@ -24429,12 +24411,6 @@ func schema_apimachinery_apis_ops_v1alpha1_MongoDBOpsRequestSpec(ref common.Refe
 					"updateVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specifies information necessary for upgrading MongoDB",
-							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.MongoDBUpdateVersionSpec"),
-						},
-					},
-					"upgrade": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Specifies information necessary for upgrading MongoDB Deprecated: use UpdateVersion",
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.MongoDBUpdateVersionSpec"),
 						},
 					},
@@ -24872,12 +24848,6 @@ func schema_apimachinery_apis_ops_v1alpha1_MySQLOpsRequestSpec(ref common.Refere
 					"updateVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specifies information necessary for upgrading MySQL",
-							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.MySQLUpdateVersionSpec"),
-						},
-					},
-					"upgrade": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Specifies information necessary for upgrading MySQL Deprecated: use UpdateVersion",
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.MySQLUpdateVersionSpec"),
 						},
 					},
@@ -25393,12 +25363,6 @@ func schema_apimachinery_apis_ops_v1alpha1_PerconaXtraDBOpsRequestSpec(ref commo
 					"updateVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specifies information necessary for upgrading PerconaXtraDB",
-							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PerconaXtraDBUpdateVersionSpec"),
-						},
-					},
-					"upgrade": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Specifies information necessary for upgrading PerconaXtraDB Deprecated: use UpdateVersion",
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PerconaXtraDBUpdateVersionSpec"),
 						},
 					},
@@ -26112,12 +26076,6 @@ func schema_apimachinery_apis_ops_v1alpha1_PostgresOpsRequestSpec(ref common.Ref
 					"updateVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specifies information necessary for upgrading Postgres",
-							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PostgresUpdateVersionSpec"),
-						},
-					},
-					"upgrade": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Specifies information necessary for upgrading Postgres Deprecated: use UpdateVersion",
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PostgresUpdateVersionSpec"),
 						},
 					},

--- a/apis/ops/v1alpha1/perconaxtradb_ops_helpers.go
+++ b/apis/ops/v1alpha1/perconaxtradb_ops_helpers.go
@@ -63,21 +63,6 @@ func (p *PerconaXtraDBOpsRequest) GetObjectMeta() metav1.ObjectMeta {
 	return p.ObjectMeta
 }
 
-func (p PerconaXtraDBOpsRequest) GetRequestType() any {
-	switch p.Spec.Type {
-	case PerconaXtraDBOpsRequestTypeUpgrade:
-		return PerconaXtraDBOpsRequestTypeUpdateVersion
-	}
-	return p.Spec.Type
-}
-
-func (p PerconaXtraDBOpsRequest) GetUpdateVersionSpec() *PerconaXtraDBUpdateVersionSpec {
-	if p.Spec.UpdateVersion != nil {
-		return p.Spec.UpdateVersion
-	}
-	return p.Spec.Upgrade
-}
-
 func (p *PerconaXtraDBOpsRequest) GetDBRefName() string {
 	return p.Spec.DatabaseRef.Name
 }

--- a/apis/ops/v1alpha1/perconaxtradb_ops_types.go
+++ b/apis/ops/v1alpha1/perconaxtradb_ops_types.go
@@ -57,9 +57,6 @@ type PerconaXtraDBOpsRequestSpec struct {
 	Type PerconaXtraDBOpsRequestType `json:"type"`
 	// Specifies information necessary for upgrading PerconaXtraDB
 	UpdateVersion *PerconaXtraDBUpdateVersionSpec `json:"updateVersion,omitempty"`
-	// Specifies information necessary for upgrading PerconaXtraDB
-	// Deprecated: use UpdateVersion
-	Upgrade *PerconaXtraDBUpdateVersionSpec `json:"upgrade,omitempty"`
 	// Specifies information necessary for horizontal scaling
 	HorizontalScaling *PerconaXtraDBHorizontalScalingSpec `json:"horizontalScaling,omitempty"`
 	// Specifies information necessary for vertical scaling
@@ -80,7 +77,7 @@ type PerconaXtraDBOpsRequestSpec struct {
 }
 
 // +kubebuilder:validation:Enum=Upgrade;UpdateVersion;HorizontalScaling;VerticalScaling;VolumeExpansion;Restart;Reconfigure;ReconfigureTLS
-// ENUM(Upgrade, UpdateVersion, HorizontalScaling, VerticalScaling, VolumeExpansion, Restart, Reconfigure, ReconfigureTLS)
+// ENUM(UpdateVersion, HorizontalScaling, VerticalScaling, VolumeExpansion, Restart, Reconfigure, ReconfigureTLS)
 type PerconaXtraDBOpsRequestType string
 
 // PerconaXtraDBReplicaReadinessCriteria is the criteria for checking readiness of an PerconaXtraDB database

--- a/apis/ops/v1alpha1/perconaxtradb_ops_types_enum.go
+++ b/apis/ops/v1alpha1/perconaxtradb_ops_types_enum.go
@@ -12,8 +12,6 @@ import (
 )
 
 const (
-	// PerconaXtraDBOpsRequestTypeUpgrade is a PerconaXtraDBOpsRequestType of type Upgrade.
-	PerconaXtraDBOpsRequestTypeUpgrade PerconaXtraDBOpsRequestType = "Upgrade"
 	// PerconaXtraDBOpsRequestTypeUpdateVersion is a PerconaXtraDBOpsRequestType of type UpdateVersion.
 	PerconaXtraDBOpsRequestTypeUpdateVersion PerconaXtraDBOpsRequestType = "UpdateVersion"
 	// PerconaXtraDBOpsRequestTypeHorizontalScaling is a PerconaXtraDBOpsRequestType of type HorizontalScaling.
@@ -33,7 +31,6 @@ const (
 var ErrInvalidPerconaXtraDBOpsRequestType = fmt.Errorf("not a valid PerconaXtraDBOpsRequestType, try [%s]", strings.Join(_PerconaXtraDBOpsRequestTypeNames, ", "))
 
 var _PerconaXtraDBOpsRequestTypeNames = []string{
-	string(PerconaXtraDBOpsRequestTypeUpgrade),
 	string(PerconaXtraDBOpsRequestTypeUpdateVersion),
 	string(PerconaXtraDBOpsRequestTypeHorizontalScaling),
 	string(PerconaXtraDBOpsRequestTypeVerticalScaling),
@@ -53,7 +50,6 @@ func PerconaXtraDBOpsRequestTypeNames() []string {
 // PerconaXtraDBOpsRequestTypeValues returns a list of the values for PerconaXtraDBOpsRequestType
 func PerconaXtraDBOpsRequestTypeValues() []PerconaXtraDBOpsRequestType {
 	return []PerconaXtraDBOpsRequestType{
-		PerconaXtraDBOpsRequestTypeUpgrade,
 		PerconaXtraDBOpsRequestTypeUpdateVersion,
 		PerconaXtraDBOpsRequestTypeHorizontalScaling,
 		PerconaXtraDBOpsRequestTypeVerticalScaling,
@@ -77,7 +73,6 @@ func (x PerconaXtraDBOpsRequestType) IsValid() bool {
 }
 
 var _PerconaXtraDBOpsRequestTypeValue = map[string]PerconaXtraDBOpsRequestType{
-	"Upgrade":           PerconaXtraDBOpsRequestTypeUpgrade,
 	"UpdateVersion":     PerconaXtraDBOpsRequestTypeUpdateVersion,
 	"HorizontalScaling": PerconaXtraDBOpsRequestTypeHorizontalScaling,
 	"VerticalScaling":   PerconaXtraDBOpsRequestTypeVerticalScaling,

--- a/apis/ops/v1alpha1/pgbouncer_ops_helpers.go
+++ b/apis/ops/v1alpha1/pgbouncer_ops_helpers.go
@@ -63,14 +63,6 @@ func (p *PgBouncerOpsRequest) GetObjectMeta() metav1.ObjectMeta {
 	return p.ObjectMeta
 }
 
-func (p PgBouncerOpsRequest) GetRequestType() any {
-	return p.Spec.Type
-}
-
-func (p PgBouncerOpsRequest) GetUpdateVersionSpec() *PgBouncerUpdateVersionSpec {
-	return p.Spec.UpdateVersion
-}
-
 func (p *PgBouncerOpsRequest) GetDBRefName() string {
 	return p.Spec.ServerRef.Name
 }

--- a/apis/ops/v1alpha1/postgres_ops_helpers.go
+++ b/apis/ops/v1alpha1/postgres_ops_helpers.go
@@ -63,21 +63,6 @@ func (p *PostgresOpsRequest) GetObjectMeta() metav1.ObjectMeta {
 	return p.ObjectMeta
 }
 
-func (p PostgresOpsRequest) GetRequestType() any {
-	switch p.Spec.Type {
-	case PostgresOpsRequestTypeUpgrade:
-		return PostgresOpsRequestTypeUpdateVersion
-	}
-	return p.Spec.Type
-}
-
-func (p PostgresOpsRequest) GetUpdateVersionSpec() *PostgresUpdateVersionSpec {
-	if p.Spec.UpdateVersion != nil {
-		return p.Spec.UpdateVersion
-	}
-	return p.Spec.Upgrade
-}
-
 func (p *PostgresOpsRequest) GetDBRefName() string {
 	return p.Spec.DatabaseRef.Name
 }

--- a/apis/ops/v1alpha1/postgres_ops_types.go
+++ b/apis/ops/v1alpha1/postgres_ops_types.go
@@ -70,9 +70,6 @@ type PostgresOpsRequestSpec struct {
 	Type PostgresOpsRequestType `json:"type"`
 	// Specifies information necessary for upgrading Postgres
 	UpdateVersion *PostgresUpdateVersionSpec `json:"updateVersion,omitempty"`
-	// Specifies information necessary for upgrading Postgres
-	// Deprecated: use UpdateVersion
-	Upgrade *PostgresUpdateVersionSpec `json:"upgrade,omitempty"`
 	// Specifies information necessary for horizontal scaling
 	HorizontalScaling *PostgresHorizontalScalingSpec `json:"horizontalScaling,omitempty"`
 	// Specifies information necessary for vertical scaling
@@ -93,7 +90,7 @@ type PostgresOpsRequestSpec struct {
 }
 
 // +kubebuilder:validation:Enum=Upgrade;UpdateVersion;HorizontalScaling;VerticalScaling;VolumeExpansion;Restart;Reconfigure;ReconfigureTLS
-// ENUM(Upgrade, UpdateVersion, HorizontalScaling, VerticalScaling, VolumeExpansion, Restart, Reconfigure, ReconfigureTLS)
+// ENUM(UpdateVersion, HorizontalScaling, VerticalScaling, VolumeExpansion, Restart, Reconfigure, ReconfigureTLS)
 type PostgresOpsRequestType string
 
 type PostgresUpdateVersionSpec struct {

--- a/apis/ops/v1alpha1/postgres_ops_types_enum.go
+++ b/apis/ops/v1alpha1/postgres_ops_types_enum.go
@@ -12,8 +12,6 @@ import (
 )
 
 const (
-	// PostgresOpsRequestTypeUpgrade is a PostgresOpsRequestType of type Upgrade.
-	PostgresOpsRequestTypeUpgrade PostgresOpsRequestType = "Upgrade"
 	// PostgresOpsRequestTypeUpdateVersion is a PostgresOpsRequestType of type UpdateVersion.
 	PostgresOpsRequestTypeUpdateVersion PostgresOpsRequestType = "UpdateVersion"
 	// PostgresOpsRequestTypeHorizontalScaling is a PostgresOpsRequestType of type HorizontalScaling.
@@ -33,7 +31,6 @@ const (
 var ErrInvalidPostgresOpsRequestType = fmt.Errorf("not a valid PostgresOpsRequestType, try [%s]", strings.Join(_PostgresOpsRequestTypeNames, ", "))
 
 var _PostgresOpsRequestTypeNames = []string{
-	string(PostgresOpsRequestTypeUpgrade),
 	string(PostgresOpsRequestTypeUpdateVersion),
 	string(PostgresOpsRequestTypeHorizontalScaling),
 	string(PostgresOpsRequestTypeVerticalScaling),
@@ -53,7 +50,6 @@ func PostgresOpsRequestTypeNames() []string {
 // PostgresOpsRequestTypeValues returns a list of the values for PostgresOpsRequestType
 func PostgresOpsRequestTypeValues() []PostgresOpsRequestType {
 	return []PostgresOpsRequestType{
-		PostgresOpsRequestTypeUpgrade,
 		PostgresOpsRequestTypeUpdateVersion,
 		PostgresOpsRequestTypeHorizontalScaling,
 		PostgresOpsRequestTypeVerticalScaling,
@@ -77,7 +73,6 @@ func (x PostgresOpsRequestType) IsValid() bool {
 }
 
 var _PostgresOpsRequestTypeValue = map[string]PostgresOpsRequestType{
-	"Upgrade":           PostgresOpsRequestTypeUpgrade,
 	"UpdateVersion":     PostgresOpsRequestTypeUpdateVersion,
 	"HorizontalScaling": PostgresOpsRequestTypeHorizontalScaling,
 	"VerticalScaling":   PostgresOpsRequestTypeVerticalScaling,

--- a/apis/ops/v1alpha1/proxysql_ops_helpers.go
+++ b/apis/ops/v1alpha1/proxysql_ops_helpers.go
@@ -59,14 +59,6 @@ func (p *ProxySQLOpsRequest) GetObjectMeta() metav1.ObjectMeta {
 	return p.ObjectMeta
 }
 
-func (p ProxySQLOpsRequest) GetRequestType() any {
-	return p.Spec.Type
-}
-
-func (p ProxySQLOpsRequest) GetUpdateVersionSpec() *ProxySQLUpdateVersionSpec {
-	return p.Spec.UpdateVersion
-}
-
 func (p *ProxySQLOpsRequest) GetDBRefName() string {
 	return p.Spec.ProxyRef.Name
 }

--- a/apis/ops/v1alpha1/redis_ops_helpers.go
+++ b/apis/ops/v1alpha1/redis_ops_helpers.go
@@ -63,14 +63,6 @@ func (r *RedisOpsRequest) GetObjectMeta() metav1.ObjectMeta {
 	return r.ObjectMeta
 }
 
-func (r RedisOpsRequest) GetRequestType() any {
-	return r.Spec.Type
-}
-
-func (r RedisOpsRequest) GetUpdateVersionSpec() *RedisUpdateVersionSpec {
-	return r.Spec.UpdateVersion
-}
-
 func (r *RedisOpsRequest) GetDBRefName() string {
 	return r.Spec.DatabaseRef.Name
 }

--- a/apis/ops/v1alpha1/redis_sentinel_ops_helpers.go
+++ b/apis/ops/v1alpha1/redis_sentinel_ops_helpers.go
@@ -63,14 +63,6 @@ func (r *RedisSentinelOpsRequest) GetObjectMeta() metav1.ObjectMeta {
 	return r.ObjectMeta
 }
 
-func (r RedisSentinelOpsRequest) GetRequestType() any {
-	return r.Spec.Type
-}
-
-func (r RedisSentinelOpsRequest) GetUpdateVersionSpec() *RedisSentinelUpdateVersionSpec {
-	return r.Spec.UpdateVersion
-}
-
 func (r *RedisSentinelOpsRequest) GetDBRefName() string {
 	return r.Spec.DatabaseRef.Name
 }

--- a/apis/ops/v1alpha1/type.go
+++ b/apis/ops/v1alpha1/type.go
@@ -98,7 +98,6 @@ const (
 type Accessor interface {
 	GetObjectMeta() metav1.ObjectMeta
 	GetDBRefName() string
-	GetRequestType() any
 	GetStatus() OpsRequestStatus
 	SetStatus(_ OpsRequestStatus)
 }

--- a/apis/ops/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/ops/v1alpha1/zz_generated.deepcopy.go
@@ -274,11 +274,6 @@ func (in *ElasticsearchOpsRequestSpec) DeepCopyInto(out *ElasticsearchOpsRequest
 		*out = new(ElasticsearchUpdateVersionSpec)
 		**out = **in
 	}
-	if in.Upgrade != nil {
-		in, out := &in.Upgrade, &out.Upgrade
-		*out = new(ElasticsearchUpdateVersionSpec)
-		**out = **in
-	}
 	if in.HorizontalScaling != nil {
 		in, out := &in.HorizontalScaling, &out.HorizontalScaling
 		*out = new(ElasticsearchHorizontalScalingSpec)
@@ -1312,11 +1307,6 @@ func (in *MariaDBOpsRequestSpec) DeepCopyInto(out *MariaDBOpsRequestSpec) {
 		*out = new(MariaDBUpdateVersionSpec)
 		**out = **in
 	}
-	if in.Upgrade != nil {
-		in, out := &in.Upgrade, &out.Upgrade
-		*out = new(MariaDBUpdateVersionSpec)
-		**out = **in
-	}
 	if in.HorizontalScaling != nil {
 		in, out := &in.HorizontalScaling, &out.HorizontalScaling
 		*out = new(MariaDBHorizontalScalingSpec)
@@ -1603,11 +1593,6 @@ func (in *MemcachedOpsRequestSpec) DeepCopyInto(out *MemcachedOpsRequestSpec) {
 	out.DatabaseRef = in.DatabaseRef
 	if in.UpdateVersion != nil {
 		in, out := &in.UpdateVersion, &out.UpdateVersion
-		*out = new(MemcachedUpdateVersionSpec)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.Upgrade != nil {
-		in, out := &in.Upgrade, &out.Upgrade
 		*out = new(MemcachedUpdateVersionSpec)
 		(*in).DeepCopyInto(*out)
 	}
@@ -1915,11 +1900,6 @@ func (in *MongoDBOpsRequestSpec) DeepCopyInto(out *MongoDBOpsRequestSpec) {
 	out.DatabaseRef = in.DatabaseRef
 	if in.UpdateVersion != nil {
 		in, out := &in.UpdateVersion, &out.UpdateVersion
-		*out = new(MongoDBUpdateVersionSpec)
-		**out = **in
-	}
-	if in.Upgrade != nil {
-		in, out := &in.Upgrade, &out.Upgrade
 		*out = new(MongoDBUpdateVersionSpec)
 		**out = **in
 	}
@@ -2261,11 +2241,6 @@ func (in *MySQLOpsRequestSpec) DeepCopyInto(out *MySQLOpsRequestSpec) {
 	out.DatabaseRef = in.DatabaseRef
 	if in.UpdateVersion != nil {
 		in, out := &in.UpdateVersion, &out.UpdateVersion
-		*out = new(MySQLUpdateVersionSpec)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.Upgrade != nil {
-		in, out := &in.Upgrade, &out.Upgrade
 		*out = new(MySQLUpdateVersionSpec)
 		(*in).DeepCopyInto(*out)
 	}
@@ -2622,11 +2597,6 @@ func (in *PerconaXtraDBOpsRequestSpec) DeepCopyInto(out *PerconaXtraDBOpsRequest
 	out.DatabaseRef = in.DatabaseRef
 	if in.UpdateVersion != nil {
 		in, out := &in.UpdateVersion, &out.UpdateVersion
-		*out = new(PerconaXtraDBUpdateVersionSpec)
-		**out = **in
-	}
-	if in.Upgrade != nil {
-		in, out := &in.Upgrade, &out.Upgrade
 		*out = new(PerconaXtraDBUpdateVersionSpec)
 		**out = **in
 	}
@@ -3162,11 +3132,6 @@ func (in *PostgresOpsRequestSpec) DeepCopyInto(out *PostgresOpsRequestSpec) {
 	out.DatabaseRef = in.DatabaseRef
 	if in.UpdateVersion != nil {
 		in, out := &in.UpdateVersion, &out.UpdateVersion
-		*out = new(PostgresUpdateVersionSpec)
-		**out = **in
-	}
-	if in.Upgrade != nil {
-		in, out := &in.Upgrade, &out.Upgrade
 		*out = new(PostgresUpdateVersionSpec)
 		**out = **in
 	}

--- a/crds/ops.kubedb.com_elasticsearchopsrequests.yaml
+++ b/crds/ops.kubedb.com_elasticsearchopsrequests.yaml
@@ -244,11 +244,6 @@ spec:
                   targetVersion:
                     type: string
                 type: object
-              upgrade:
-                properties:
-                  targetVersion:
-                    type: string
-                type: object
               verticalScaling:
                 properties:
                   exporter:

--- a/crds/ops.kubedb.com_mariadbopsrequests.yaml
+++ b/crds/ops.kubedb.com_mariadbopsrequests.yaml
@@ -207,11 +207,6 @@ spec:
                   targetVersion:
                     type: string
                 type: object
-              upgrade:
-                properties:
-                  targetVersion:
-                    type: string
-                type: object
               verticalScaling:
                 properties:
                   coordinator:

--- a/crds/ops.kubedb.com_memcachedopsrequests.yaml
+++ b/crds/ops.kubedb.com_memcachedopsrequests.yaml
@@ -183,13 +183,6 @@ spec:
                   targetVersion:
                     type: string
                 type: object
-              upgrade:
-                properties:
-                  readinessCriteria:
-                    type: object
-                  targetVersion:
-                    type: string
-                type: object
               verticalScaling:
                 properties:
                   readinessCriteria:

--- a/crds/ops.kubedb.com_mongodbopsrequests.yaml
+++ b/crds/ops.kubedb.com_mongodbopsrequests.yaml
@@ -349,11 +349,6 @@ spec:
                   targetVersion:
                     type: string
                 type: object
-              upgrade:
-                properties:
-                  targetVersion:
-                    type: string
-                type: object
               verticalScaling:
                 properties:
                   arbiter:

--- a/crds/ops.kubedb.com_mysqlopsrequests.yaml
+++ b/crds/ops.kubedb.com_mysqlopsrequests.yaml
@@ -202,13 +202,6 @@ spec:
                   targetVersion:
                     type: string
                 type: object
-              upgrade:
-                properties:
-                  readinessCriteria:
-                    type: object
-                  targetVersion:
-                    type: string
-                type: object
               verticalScaling:
                 properties:
                   coordinator:

--- a/crds/ops.kubedb.com_perconaxtradbopsrequests.yaml
+++ b/crds/ops.kubedb.com_perconaxtradbopsrequests.yaml
@@ -207,11 +207,6 @@ spec:
                   targetVersion:
                     type: string
                 type: object
-              upgrade:
-                properties:
-                  targetVersion:
-                    type: string
-                type: object
               verticalScaling:
                 properties:
                   coordinator:

--- a/crds/ops.kubedb.com_postgresopsrequests.yaml
+++ b/crds/ops.kubedb.com_postgresopsrequests.yaml
@@ -225,11 +225,6 @@ spec:
                   targetVersion:
                     type: string
                 type: object
-              upgrade:
-                properties:
-                  targetVersion:
-                    type: string
-                type: object
               verticalScaling:
                 properties:
                   coordinator:


### PR DESCRIPTION
This is a breaking change. This field has been replaced by `spec.updateVersion` and `UpdateVersion` type ops request > 12 months ago.