### PR TITLE
Fix druid by adding Postgres as metadata storage type 

### DIFF
--- a/apis/kubedb/constants.go
+++ b/apis/kubedb/constants.go
@@ -978,6 +978,8 @@ const (
 	DruidPortRouters        = 8888
 	DruidExporterPort       = 9104
 
+	DruidMetadataStorageTypePostgres = "Postgres"
+
 	// Common Runtime Configurations Properties
 	// ZooKeeper
 	DruidZKServiceHost              = "druid.zk.service.host"

--- a/apis/kubedb/v1alpha2/druid_helpers.go
+++ b/apis/kubedb/v1alpha2/druid_helpers.go
@@ -316,7 +316,8 @@ func (d *Druid) AddDruidExtensionLoadList(druidExtensionLoadList string, extensi
 func (d *Druid) GetMetadataStorageType(metadataStorage string) DruidMetadataStorageType {
 	if metadataStorage == string(DruidMetadataStorageMySQL) || metadataStorage == strings.ToLower(string(DruidMetadataStorageMySQL)) {
 		return DruidMetadataStorageMySQL
-	} else if metadataStorage == string(DruidMetadataStoragePostgreSQL) || metadataStorage == strings.ToLower(string(DruidMetadataStoragePostgreSQL)) {
+	} else if metadataStorage == string(DruidMetadataStoragePostgreSQL) || metadataStorage == strings.ToLower(string(DruidMetadataStoragePostgreSQL)) ||
+		metadataStorage == kubedb.DruidMetadataStorageTypePostgres || metadataStorage == strings.ToLower(string(kubedb.DruidMetadataStorageTypePostgres)) {
 		return DruidMetadataStoragePostgreSQL
 	} else {
 		panic(fmt.Sprintf("Unknown metadata storage type: %s", metadataStorage))


### PR DESCRIPTION
- Kind of PostgreSQL is Postgres if it is KubeDB Managed 
- Need to allow metadata storage type to be set from this Kind