### PR TITLE
fix: register Ignite autoscaler

### DIFF
--- a/apis/autoscaling/v1alpha1/register.go
+++ b/apis/autoscaling/v1alpha1/register.go
@@ -68,6 +68,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&FerretDBAutoscalerList{},
 		&HazelcastAutoscaler{},
 		&HazelcastAutoscalerList{},
+		&IgniteAutoscaler{},
+		&IgniteAutoscalerList{},
 		&KafkaAutoscaler{},
 		&KafkaAutoscalerList{},
 		&MariaDBAutoscaler{},


### PR DESCRIPTION
Ignite autoscaler was missing from known types in register.go