### PR TITLE
Add RotateAuth OpsRequest type for Oracle

### DIFF
--- a/apis/ops/v1alpha1/openapi_generated.go
+++ b/apis/ops/v1alpha1/openapi_generated.go
@@ -39655,6 +39655,12 @@ func schema_apimachinery_apis_ops_v1alpha1_OracleOpsRequestSpec(ref common.Refer
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.ReconfigurationSpec"),
 						},
 					},
+					"authentication": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specifies information necessary for configuring authSecret of the database",
+							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.AuthSpec"),
+						},
+					},
 					"restart": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specifies information necessary for restarting database",
@@ -39672,7 +39678,7 @@ func schema_apimachinery_apis_ops_v1alpha1_OracleOpsRequestSpec(ref common.Refer
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration", "kubedb.dev/apimachinery/apis/ops/v1alpha1.ReconfigurationSpec", "kubedb.dev/apimachinery/apis/ops/v1alpha1.RestartSpec"},
+			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration", "kubedb.dev/apimachinery/apis/ops/v1alpha1.AuthSpec", "kubedb.dev/apimachinery/apis/ops/v1alpha1.ReconfigurationSpec", "kubedb.dev/apimachinery/apis/ops/v1alpha1.RestartSpec"},
 	}
 }
 

--- a/apis/ops/v1alpha1/oracle_ops_types.go
+++ b/apis/ops/v1alpha1/oracle_ops_types.go
@@ -56,14 +56,16 @@ type OracleOpsRequestSpec struct {
 	Type OracleOpsRequestType `json:"type"`
 	// Specifies information necessary for custom configuration of oracle
 	Configuration *ReconfigurationSpec `json:"configuration,omitempty"`
+	// Specifies information necessary for configuring authSecret of the database
+	Authentication *AuthSpec `json:"authentication,omitempty"`
 	// Specifies information necessary for restarting database
 	Restart *RestartSpec `json:"restart,omitempty"`
 	// Timeout for each step of the ops request in second. If a step doesn't finish within the specified timeout, the ops request will result in failure.
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=Restart;Reconfigure
-// ENUM(Restart, Reconfigure)
+// +kubebuilder:validation:Enum=Restart;Reconfigure;RotateAuth
+// ENUM(Restart, Reconfigure, RotateAuth)
 type OracleOpsRequestType string
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/apis/ops/v1alpha1/oracle_ops_types_enum.go
+++ b/apis/ops/v1alpha1/oracle_ops_types_enum.go
@@ -15,6 +15,8 @@ const (
 	OracleOpsRequestTypeRestart OracleOpsRequestType = "Restart"
 	// OracleOpsRequestTypeReconfigure is a OracleOpsRequestType of type Reconfigure.
 	OracleOpsRequestTypeReconfigure OracleOpsRequestType = "Reconfigure"
+	// OracleOpsRequestTypeRotateAuth is a OracleOpsRequestType of type RotateAuth.
+	OracleOpsRequestTypeRotateAuth OracleOpsRequestType = "RotateAuth"
 )
 
 var ErrInvalidOracleOpsRequestType = fmt.Errorf("not a valid OracleOpsRequestType, try [%s]", strings.Join(_OracleOpsRequestTypeNames, ", "))
@@ -22,6 +24,7 @@ var ErrInvalidOracleOpsRequestType = fmt.Errorf("not a valid OracleOpsRequestTyp
 var _OracleOpsRequestTypeNames = []string{
 	string(OracleOpsRequestTypeRestart),
 	string(OracleOpsRequestTypeReconfigure),
+	string(OracleOpsRequestTypeRotateAuth),
 }
 
 // OracleOpsRequestTypeNames returns a list of possible string values of OracleOpsRequestType.
@@ -36,6 +39,7 @@ func OracleOpsRequestTypeValues() []OracleOpsRequestType {
 	return []OracleOpsRequestType{
 		OracleOpsRequestTypeRestart,
 		OracleOpsRequestTypeReconfigure,
+		OracleOpsRequestTypeRotateAuth,
 	}
 }
 
@@ -54,6 +58,7 @@ func (x OracleOpsRequestType) IsValid() bool {
 var _OracleOpsRequestTypeValue = map[string]OracleOpsRequestType{
 	"Restart":     OracleOpsRequestTypeRestart,
 	"Reconfigure": OracleOpsRequestTypeReconfigure,
+	"RotateAuth":  OracleOpsRequestTypeRotateAuth,
 }
 
 // ParseOracleOpsRequestType attempts to convert a string to a OracleOpsRequestType.

--- a/apis/ops/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/ops/v1alpha1/zz_generated.deepcopy.go
@@ -4418,6 +4418,11 @@ func (in *OracleOpsRequestSpec) DeepCopyInto(out *OracleOpsRequestSpec) {
 		*out = new(ReconfigurationSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Authentication != nil {
+		in, out := &in.Authentication, &out.Authentication
+		*out = new(AuthSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Restart != nil {
 		in, out := &in.Restart, &out.Restart
 		*out = new(RestartSpec)

--- a/crds/ops.kubedb.com_oracleopsrequests.yaml
+++ b/crds/ops.kubedb.com_oracleopsrequests.yaml
@@ -42,6 +42,24 @@ spec:
             type: object
           spec:
             properties:
+              authentication:
+                properties:
+                  secretRef:
+                    properties:
+                      apiGroup:
+                        default: ""
+                        type: string
+                      kind:
+                        default: Secret
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
               configuration:
                 properties:
                   applyConfig:
@@ -80,6 +98,7 @@ spec:
                 enum:
                 - Restart
                 - Reconfigure
+                - RotateAuth
                 type: string
             required:
             - databaseRef


### PR DESCRIPTION
## Summary
- Add OracleOpsRequestRotateAuth spec mirroring the RabbitMQ rotate-auth API
- Add RotateAuth enum value to OracleOpsRequestType
- Add accessor helpers in oracle_ops_helpers.go

Stacked on top of `add-oracle-ops-restart`.

## Test plan
- [ ] CRDs regenerate cleanly downstream
- [ ] Oracle operator PR (oracle-rotate-auth) compiles against this