### PR TITLE
Add CiliumNetworkPolicy flavor support

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -105,7 +105,11 @@ type Config struct {
 	MaxNumRequeues         int
 	NumThreads             int
 	NetworkPolicyEnabled   bool
-	ShardConfig            string
+	// NetworkPolicyFlavor selects which NetworkPolicy API the operator emits
+	// per DB namespace. Accepted values: "kubernetes" (default) or "cilium".
+	// Empty defaults to "kubernetes".
+	NetworkPolicyFlavor string
+	ShardConfig         string
 }
 
 type Initializers struct {

--- a/pkg/network_policy/cilium.go
+++ b/pkg/network_policy/cilium.go
@@ -54,7 +54,7 @@ func ensureCiliumPolicies(kbClient client.Client, dbNs string) error {
 // ensureCiliumNetworkPolicy upserts a CiliumNetworkPolicy with the given name,
 // namespace, and spec. The spec is provided as a plain Go map matching the
 // cilium.io/v2 CRD schema; using unstructured avoids vendoring cilium.
-func ensureCiliumNetworkPolicy(kbClient client.Client, namespace, name string, spec map[string]interface{}) error {
+func ensureCiliumNetworkPolicy(kbClient client.Client, namespace, name string, spec map[string]any) error {
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(ciliumNetworkPolicyGVK)
 	u.SetName(name)
@@ -69,15 +69,15 @@ func ensureCiliumNetworkPolicy(kbClient client.Client, namespace, name string, s
 }
 
 func ensureCiliumHealthCheckerPolicy(kbClient client.Client, dbNs string) error {
-	spec := map[string]interface{}{
-		"endpointSelector": map[string]interface{}{
+	spec := map[string]any{
+		"endpointSelector": map[string]any{
 			"matchLabels": stringMapToInterface(api.GetSelectorForNetworkPolicy()),
 		},
-		"ingress": []interface{}{
-			map[string]interface{}{
-				"fromEndpoints": []interface{}{
-					map[string]interface{}{
-						"matchLabels": map[string]interface{}{
+		"ingress": []any{
+			map[string]any{
+				"fromEndpoints": []any{
+					map[string]any{
+						"matchLabels": map[string]any{
 							//"k8s:" + corev1.LabelMetadataName:   meta_util.PodNamespace(),
 							"k8s:io.kubernetes.pod.namespace":   meta_util.PodNamespace(),
 							"k8s:" + meta_util.InstanceLabelKey: "kubedb-provisioner",
@@ -91,56 +91,56 @@ func ensureCiliumHealthCheckerPolicy(kbClient client.Client, dbNs string) error 
 }
 
 func ensureCiliumDBInternalPolicy(kbClient client.Client, dbNs string) error {
-	spec := map[string]interface{}{
-		"endpointSelector": map[string]interface{}{
+	spec := map[string]any{
+		"endpointSelector": map[string]any{
 			"matchLabels": stringMapToInterface(api.GetSelectorForNetworkPolicy()),
 		},
-		"ingress": []interface{}{
-			map[string]interface{}{
-				"fromEndpoints": []interface{}{
-					map[string]interface{}{
-						"matchLabels": map[string]interface{}{
+		"ingress": []any{
+			map[string]any{
+				"fromEndpoints": []any{
+					map[string]any{
+						"matchLabels": map[string]any{
 							"k8s:io.kubernetes.pod.namespace": dbNs,
 						},
 					},
 				},
 			},
 		},
-		"egress": []interface{}{
+		"egress": []any{
 			// Intra-namespace egress to peer DB pods (replication, gossip, etc).
-			map[string]interface{}{
-				"toEndpoints": []interface{}{
-					map[string]interface{}{
-						"matchLabels": map[string]interface{}{
+			map[string]any{
+				"toEndpoints": []any{
+					map[string]any{
+						"matchLabels": map[string]any{
 							"k8s:io.kubernetes.pod.namespace": dbNs,
 						},
 					},
 				},
 			},
 			// World egress (image pulls, telemetry, etc).
-			map[string]interface{}{
-				"toEntities": []interface{}{"world"},
+			map[string]any{
+				"toEntities": []any{"world"},
 			},
 			// DNS egress to kube-dns so pods can resolve cluster-internal names.
 			// Cilium uses k8s:io.kubernetes.pod.namespace (not k8s:kubernetes.io/metadata.name)
 			// as the namespace label in pod identities.
-			map[string]interface{}{
-				"toEndpoints": []interface{}{
-					map[string]interface{}{
-						"matchLabels": map[string]interface{}{
+			map[string]any{
+				"toEndpoints": []any{
+					map[string]any{
+						"matchLabels": map[string]any{
 							"k8s:io.kubernetes.pod.namespace": "kube-system",
 							"k8s:k8s-app":                     "kube-dns",
 						},
 					},
 				},
-				"toPorts": []interface{}{
-					map[string]interface{}{
-						"ports": []interface{}{
-							map[string]interface{}{
+				"toPorts": []any{
+					map[string]any{
+						"ports": []any{
+							map[string]any{
 								"port":     "53",
 								"protocol": "UDP",
 							},
-							map[string]interface{}{
+							map[string]any{
 								"port":     "53",
 								"protocol": "TCP",
 							},
@@ -157,13 +157,13 @@ func ensureCiliumDBInternalPolicy(kbClient client.Client, dbNs string) error {
 // Cluster databases (>1 replica) need this for leader election and operator
 // SDK interactions; standalone DBs are unaffected by its presence.
 func ensureCiliumKubeAPIPolicy(kbClient client.Client, dbNs string) error {
-	spec := map[string]interface{}{
-		"endpointSelector": map[string]interface{}{
+	spec := map[string]any{
+		"endpointSelector": map[string]any{
 			"matchLabels": stringMapToInterface(api.GetSelectorForNetworkPolicy()),
 		},
-		"egress": []interface{}{
-			map[string]interface{}{
-				"toEntities": []interface{}{"kube-apiserver"},
+		"egress": []any{
+			map[string]any{
+				"toEntities": []any{"kube-apiserver"},
 			},
 		},
 	}
@@ -171,34 +171,34 @@ func ensureCiliumKubeAPIPolicy(kbClient client.Client, dbNs string) error {
 }
 
 func ensureCiliumBackupPolicy(kbClient client.Client, dbNs string) error {
-	spec := map[string]interface{}{
-		"endpointSelector": map[string]interface{}{
-			"matchLabels": map[string]interface{}{
+	spec := map[string]any{
+		"endpointSelector": map[string]any{
+			"matchLabels": map[string]any{
 				"k8s:" + meta_util.ManagedByLabelKey: kubestashapi.KubeStashKey,
 			},
 		},
-		"egress": []interface{}{
+		"egress": []any{
 			// Reach the DB pods in this namespace.
-			map[string]interface{}{
-				"toEndpoints": []interface{}{
-					map[string]interface{}{
-						"matchLabels": map[string]interface{}{
+			map[string]any{
+				"toEndpoints": []any{
+					map[string]any{
+						"matchLabels": map[string]any{
 							"k8s:io.kubernetes.pod.namespace": dbNs,
 						},
 					},
 				},
 			},
 			// Reach object storage / external endpoints.
-			map[string]interface{}{
-				"toEntities": []interface{}{"world"},
+			map[string]any{
+				"toEntities": []any{"world"},
 			},
 		},
 	}
 	return ensureCiliumNetworkPolicy(kbClient, dbNs, NetworkPolicyNameDBBackup, spec)
 }
 
-func stringMapToInterface(in map[string]string) map[string]interface{} {
-	out := make(map[string]interface{}, len(in))
+func stringMapToInterface(in map[string]string) map[string]any {
+	out := make(map[string]any, len(in))
 	for k, v := range in {
 		out[k] = v
 	}

--- a/pkg/network_policy/cilium.go
+++ b/pkg/network_policy/cilium.go
@@ -21,7 +21,6 @@ import (
 
 	api "kubedb.dev/apimachinery/apis/kubedb/v1"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	cu "kmodules.xyz/client-go/client"
@@ -79,8 +78,9 @@ func ensureCiliumHealthCheckerPolicy(kbClient client.Client, dbNs string) error 
 				"fromEndpoints": []interface{}{
 					map[string]interface{}{
 						"matchLabels": map[string]interface{}{
-							"k8s:" + corev1.LabelMetadataName:   meta_util.PodNamespace(),
-							"k8s:" + meta_util.InstanceLabelKey: "kubedb",
+							//"k8s:" + corev1.LabelMetadataName:   meta_util.PodNamespace(),
+							"k8s:io.kubernetes.pod.namespace":   meta_util.PodNamespace(),
+							"k8s:" + meta_util.InstanceLabelKey: "kubedb-provisioner",
 						},
 					},
 				},
@@ -100,7 +100,7 @@ func ensureCiliumDBInternalPolicy(kbClient client.Client, dbNs string) error {
 				"fromEndpoints": []interface{}{
 					map[string]interface{}{
 						"matchLabels": map[string]interface{}{
-							"k8s:" + corev1.LabelMetadataName: dbNs,
+							"k8s:io.kubernetes.pod.namespace": dbNs,
 						},
 					},
 				},
@@ -112,7 +112,7 @@ func ensureCiliumDBInternalPolicy(kbClient client.Client, dbNs string) error {
 				"toEndpoints": []interface{}{
 					map[string]interface{}{
 						"matchLabels": map[string]interface{}{
-							"k8s:" + corev1.LabelMetadataName: dbNs,
+							"k8s:io.kubernetes.pod.namespace": dbNs,
 						},
 					},
 				},
@@ -120,6 +120,33 @@ func ensureCiliumDBInternalPolicy(kbClient client.Client, dbNs string) error {
 			// World egress (image pulls, telemetry, etc).
 			map[string]interface{}{
 				"toEntities": []interface{}{"world"},
+			},
+			// DNS egress to kube-dns so pods can resolve cluster-internal names.
+			// Cilium uses k8s:io.kubernetes.pod.namespace (not k8s:kubernetes.io/metadata.name)
+			// as the namespace label in pod identities.
+			map[string]interface{}{
+				"toEndpoints": []interface{}{
+					map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"k8s:io.kubernetes.pod.namespace": "kube-system",
+							"k8s:k8s-app":                     "kube-dns",
+						},
+					},
+				},
+				"toPorts": []interface{}{
+					map[string]interface{}{
+						"ports": []interface{}{
+							map[string]interface{}{
+								"port":     "53",
+								"protocol": "UDP",
+							},
+							map[string]interface{}{
+								"port":     "53",
+								"protocol": "TCP",
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -156,7 +183,7 @@ func ensureCiliumBackupPolicy(kbClient client.Client, dbNs string) error {
 				"toEndpoints": []interface{}{
 					map[string]interface{}{
 						"matchLabels": map[string]interface{}{
-							"k8s:" + corev1.LabelMetadataName: dbNs,
+							"k8s:io.kubernetes.pod.namespace": dbNs,
 						},
 					},
 				},

--- a/pkg/network_policy/cilium.go
+++ b/pkg/network_policy/cilium.go
@@ -1,0 +1,179 @@
+/*
+Copyright AppsCode Inc. and Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network_policy
+
+import (
+	"context"
+
+	api "kubedb.dev/apimachinery/apis/kubedb/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	cu "kmodules.xyz/client-go/client"
+	meta_util "kmodules.xyz/client-go/meta"
+	kubestashapi "kubestash.dev/apimachinery/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ciliumNetworkPolicyGVK is the GroupVersionKind of CiliumNetworkPolicy as
+// installed by Cilium. We use unstructured.Unstructured rather than vendoring
+// github.com/cilium/cilium to keep the apimachinery dependency tree small.
+var ciliumNetworkPolicyGVK = schema.GroupVersionKind{
+	Group:   "cilium.io",
+	Version: "v2",
+	Kind:    "CiliumNetworkPolicy",
+}
+
+func ensureCiliumPolicies(kbClient client.Client, dbNs string) error {
+	if err := ensureCiliumHealthCheckerPolicy(kbClient, dbNs); err != nil {
+		return err
+	}
+	if err := ensureCiliumDBInternalPolicy(kbClient, dbNs); err != nil {
+		return err
+	}
+	if err := ensureCiliumKubeAPIPolicy(kbClient, dbNs); err != nil {
+		return err
+	}
+	return ensureCiliumBackupPolicy(kbClient, dbNs)
+}
+
+// ensureCiliumNetworkPolicy upserts a CiliumNetworkPolicy with the given name,
+// namespace, and spec. The spec is provided as a plain Go map matching the
+// cilium.io/v2 CRD schema; using unstructured avoids vendoring cilium.
+func ensureCiliumNetworkPolicy(kbClient client.Client, namespace, name string, spec map[string]interface{}) error {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(ciliumNetworkPolicyGVK)
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	_, err := cu.CreateOrPatch(context.TODO(), kbClient, u, func(obj client.Object, createOp bool) client.Object {
+		in := obj.(*unstructured.Unstructured)
+		in.SetGroupVersionKind(ciliumNetworkPolicyGVK)
+		_ = unstructured.SetNestedMap(in.Object, spec, "spec")
+		return in
+	})
+	return err
+}
+
+func ensureCiliumHealthCheckerPolicy(kbClient client.Client, dbNs string) error {
+	spec := map[string]interface{}{
+		"endpointSelector": map[string]interface{}{
+			"matchLabels": stringMapToInterface(api.GetSelectorForNetworkPolicy()),
+		},
+		"ingress": []interface{}{
+			map[string]interface{}{
+				"fromEndpoints": []interface{}{
+					map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"k8s:" + corev1.LabelMetadataName:   meta_util.PodNamespace(),
+							"k8s:" + meta_util.InstanceLabelKey: "kubedb",
+						},
+					},
+				},
+			},
+		},
+	}
+	return ensureCiliumNetworkPolicy(kbClient, dbNs, NetworkPolicyNameHealthCheck, spec)
+}
+
+func ensureCiliumDBInternalPolicy(kbClient client.Client, dbNs string) error {
+	spec := map[string]interface{}{
+		"endpointSelector": map[string]interface{}{
+			"matchLabels": stringMapToInterface(api.GetSelectorForNetworkPolicy()),
+		},
+		"ingress": []interface{}{
+			map[string]interface{}{
+				"fromEndpoints": []interface{}{
+					map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"k8s:" + corev1.LabelMetadataName: dbNs,
+						},
+					},
+				},
+			},
+		},
+		"egress": []interface{}{
+			// Intra-namespace egress to peer DB pods (replication, gossip, etc).
+			map[string]interface{}{
+				"toEndpoints": []interface{}{
+					map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"k8s:" + corev1.LabelMetadataName: dbNs,
+						},
+					},
+				},
+			},
+			// World egress (image pulls, telemetry, etc).
+			map[string]interface{}{
+				"toEntities": []interface{}{"world"},
+			},
+		},
+	}
+	return ensureCiliumNetworkPolicy(kbClient, dbNs, NetworkPolicyNameDBInternal, spec)
+}
+
+// ensureCiliumKubeAPIPolicy allows DB pods to reach the Kubernetes API server.
+// Cluster databases (>1 replica) need this for leader election and operator
+// SDK interactions; standalone DBs are unaffected by its presence.
+func ensureCiliumKubeAPIPolicy(kbClient client.Client, dbNs string) error {
+	spec := map[string]interface{}{
+		"endpointSelector": map[string]interface{}{
+			"matchLabels": stringMapToInterface(api.GetSelectorForNetworkPolicy()),
+		},
+		"egress": []interface{}{
+			map[string]interface{}{
+				"toEntities": []interface{}{"kube-apiserver"},
+			},
+		},
+	}
+	return ensureCiliumNetworkPolicy(kbClient, dbNs, "kubedb-kube-apiserver", spec)
+}
+
+func ensureCiliumBackupPolicy(kbClient client.Client, dbNs string) error {
+	spec := map[string]interface{}{
+		"endpointSelector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{
+				"k8s:" + meta_util.ManagedByLabelKey: kubestashapi.KubeStashKey,
+			},
+		},
+		"egress": []interface{}{
+			// Reach the DB pods in this namespace.
+			map[string]interface{}{
+				"toEndpoints": []interface{}{
+					map[string]interface{}{
+						"matchLabels": map[string]interface{}{
+							"k8s:" + corev1.LabelMetadataName: dbNs,
+						},
+					},
+				},
+			},
+			// Reach object storage / external endpoints.
+			map[string]interface{}{
+				"toEntities": []interface{}{"world"},
+			},
+		},
+	}
+	return ensureCiliumNetworkPolicy(kbClient, dbNs, NetworkPolicyNameDBBackup, spec)
+}
+
+func stringMapToInterface(in map[string]string) map[string]interface{} {
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/network_policy/cilium.go
+++ b/pkg/network_policy/cilium.go
@@ -78,9 +78,8 @@ func ensureCiliumHealthCheckerPolicy(kbClient client.Client, dbNs string) error 
 				"fromEndpoints": []any{
 					map[string]any{
 						"matchLabels": map[string]any{
-							//"k8s:" + corev1.LabelMetadataName:   meta_util.PodNamespace(),
-							"k8s:io.kubernetes.pod.namespace":   meta_util.PodNamespace(),
-							"k8s:" + meta_util.InstanceLabelKey: "kubedb-provisioner",
+							"k8s:io.kubernetes.pod.namespace": meta_util.PodNamespace(),
+							"k8s:" + meta_util.NameLabelKey:   "kubedb-provisioner",
 						},
 					},
 				},

--- a/pkg/network_policy/network_policy.go
+++ b/pkg/network_policy/network_policy.go
@@ -18,6 +18,7 @@ package network_policy
 
 import (
 	"context"
+	"fmt"
 
 	api "kubedb.dev/apimachinery/apis/kubedb/v1"
 
@@ -30,19 +31,46 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// Flavor selects which NetworkPolicy API the operator emits per DB namespace.
+type Flavor string
+
+const (
+	FlavorKubernetes Flavor = "kubernetes"
+	FlavorCilium     Flavor = "cilium"
+)
+
 const (
 	NetworkPolicyNameHealthCheck = "kubedb-healthcheck"
 	NetworkPolicyNameDBInternal  = "kubedb-database-internal"
 	NetworkPolicyNameDBBackup    = "kubedb-database-backup"
 )
 
+// EnsureNetworkPolicy emits the default (FlavorKubernetes) per-DB-namespace
+// network policies. Kept for backward compatibility with the many DB operators
+// that call this function directly; new callers should prefer
+// EnsureNetworkPolicyWithFlavor.
 func EnsureNetworkPolicy(kbClient client.Client, dbNs string) error {
-	err := ensureHealthCheckerNetworkPolicy(kbClient, dbNs)
-	if err != nil {
+	return EnsureNetworkPolicyWithFlavor(kbClient, dbNs, FlavorKubernetes)
+}
+
+// EnsureNetworkPolicyWithFlavor emits the per-DB-namespace network policies in
+// the requested flavor. An empty flavor defaults to FlavorKubernetes.
+func EnsureNetworkPolicyWithFlavor(kbClient client.Client, dbNs string, flavor Flavor) error {
+	switch flavor {
+	case FlavorCilium:
+		return ensureCiliumPolicies(kbClient, dbNs)
+	case FlavorKubernetes, "":
+		return ensureKubernetesPolicies(kbClient, dbNs)
+	default:
+		return fmt.Errorf("unknown network policy flavor %q", flavor)
+	}
+}
+
+func ensureKubernetesPolicies(kbClient client.Client, dbNs string) error {
+	if err := ensureHealthCheckerNetworkPolicy(kbClient, dbNs); err != nil {
 		return err
 	}
-	err = ensureDBInternalNetworkPolicy(kbClient, dbNs)
-	if err != nil {
+	if err := ensureDBInternalNetworkPolicy(kbClient, dbNs); err != nil {
 		return err
 	}
 	return ensureBackupNetworkPolicy(kbClient, dbNs)


### PR DESCRIPTION
## Summary

- Adds a `Flavor` type and `EnsureNetworkPolicyWithFlavor` entrypoint to `pkg/network_policy`. The new entrypoint emits the per-DB-namespace network policies as either `networking.k8s.io/v1.NetworkPolicy` (default, current behavior) or `cilium.io/v2.CiliumNetworkPolicy`.
- CiliumNetworkPolicy resources are built with `unstructured.Unstructured` so the apimachinery dependency tree does not pull in `github.com/cilium/cilium`.
- Keeps the existing `EnsureNetworkPolicy(client, dbNs)` signature so the 20+ DB operator callers continue to compile unchanged. Postgres opts into the new flavor; others stay on the default.
- Adds `NetworkPolicyFlavor` to `controller.Config` so each operator can plumb the helm-chart value through to its reconciler.

Motivation: a customer running KubeDB on a Cilium-managed cluster with default-deny needs a more granular policy set than the broad `NetworkPolicy` the operator currently emits. The cilium flavor gives the operator a path to express tighter rules (entity-based egress to `kube-apiserver`, fine-grained matchLabels selectors, etc.) without changing public APIs.

## Test plan

- [x] `go build ./pkg/...` clean
- [x] `go vet ./pkg/...` clean
- [ ] Unit tests for `EnsureNetworkPolicyWithFlavor` with both flavors
- [ ] Verify on a Cilium-enabled cluster that the generated CRs apply and Hubble shows expected allowed flows

Companion PRs:
- kubedb/installer — helm chart toggle (`global.networkPolicy.flavor`) and Cilium templates for the operator namespace
- kubedb/postgres — wires the operator flag and calls `EnsureNetworkPolicyWithFlavor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)