### PR TITLE
Fix nil pointer dereferences in storage migration webhook validators

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/cert-manager/cert-manager v1.19.4
 	github.com/coreos/go-semver v0.3.1
 	github.com/evanphx/json-patch v5.9.11+incompatible
-	github.com/fatih/structs v1.1.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.7.0
@@ -104,6 +103,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fatih/color v1.18.0 // indirect
+	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect

--- a/pkg/webhooks/ops/v1alpha1/cassandra.go
+++ b/pkg/webhooks/ops/v1alpha1/cassandra.go
@@ -314,8 +314,8 @@ func (w *CassandraOpsRequestCustomWebhook) validateCassandraStorageMigrationOpsR
 	if req.Spec.Timeout == nil {
 		return errors.New("spec.timeout is required for Storage Migration ops request, adjust timeout according to the size of your database")
 	}
-	if db.Spec.Storage == nil {
-		return nil
+	if db.Spec.Storage == nil || db.Spec.Storage.StorageClassName == nil {
+		return fmt.Errorf("db.Spec.Storage.StorageClassName can't be nil in the database yaml")
 	}
 	var newstorage, oldstorage storagev1.StorageClass
 	if err := w.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: *m.StorageClassName}, &newstorage); err != nil {

--- a/pkg/webhooks/ops/v1alpha1/druid.go
+++ b/pkg/webhooks/ops/v1alpha1/druid.go
@@ -197,6 +197,9 @@ func (w *DruidOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.DruidO
 
 func (w *DruidOpsRequestCustomWebhook) validateDruidStorageMigrationOpsRequest(req *opsapi.DruidOpsRequest, db *olddbapi.Druid) error {
 	m := req.Spec.Migration
+	if m == nil {
+		return errors.New("spec.migration is required for StorageMigration type")
+	}
 	if m.StorageClassName == nil {
 		return errors.New("at least one node migration spec is required in spec.migration")
 	}

--- a/pkg/webhooks/ops/v1alpha1/elasticsearch.go
+++ b/pkg/webhooks/ops/v1alpha1/elasticsearch.go
@@ -217,6 +217,9 @@ func (w *ElasticsearchOpsRequestCustomWebhook) validateElasticsearchUpdateVersio
 
 func (w *ElasticsearchOpsRequestCustomWebhook) validateElasticsearchStorageMigrationOpsRequest(req *opsapi.ElasticsearchOpsRequest, db *dbapi.Elasticsearch) error {
 	m := req.Spec.Migration
+	if m == nil {
+		return errors.New("spec.migration is required for StorageMigration type")
+	}
 	if m.Node == nil && m.Master == nil && m.Ingest == nil && m.Data == nil &&
 		m.DataContent == nil && m.DataHot == nil && m.DataWarm == nil &&
 		m.DataCold == nil && m.DataFrozen == nil && m.ML == nil && m.Transform == nil && m.Coordinating == nil {

--- a/pkg/webhooks/ops/v1alpha1/hazelcast.go
+++ b/pkg/webhooks/ops/v1alpha1/hazelcast.go
@@ -288,8 +288,8 @@ func (w *HazelcastOpsRequestCustomWebhook) validateHazelcastStorageMigrationOpsR
 	if req.Spec.Timeout == nil {
 		return errors.New("spec.timeout is required for Storage Migration ops request, adjust timeout according to the size of your database")
 	}
-	if db.Spec.Storage == nil {
-		return nil
+	if db.Spec.Storage == nil || db.Spec.Storage.StorageClassName == nil {
+		return fmt.Errorf("db.Spec.Storage.StorageClassName can't be nil in the database yaml")
 	}
 	var newstorage, oldstorage storagev1.StorageClass
 	if err := w.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: *m.StorageClassName}, &newstorage); err != nil {

--- a/pkg/webhooks/ops/v1alpha1/ignite.go
+++ b/pkg/webhooks/ops/v1alpha1/ignite.go
@@ -212,8 +212,8 @@ func (rv *IgniteOpsRequestCustomWebhook) validateIgniteStorageMigrationOpsReques
 	if req.Spec.Timeout == nil {
 		return errors.New("spec.timeout is required for Storage Migration ops request, adjust timeout according to the size of your database")
 	}
-	if db.Spec.Storage == nil {
-		return nil
+	if db.Spec.Storage == nil || db.Spec.Storage.StorageClassName == nil {
+		return fmt.Errorf("db.Spec.Storage.StorageClassName can't be nil in the database yaml")
 	}
 	var newstorage, oldstorage storagev1.StorageClass
 	if err := rv.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: *m.StorageClassName}, &newstorage); err != nil {

--- a/pkg/webhooks/ops/v1alpha1/kafka.go
+++ b/pkg/webhooks/ops/v1alpha1/kafka.go
@@ -386,6 +386,9 @@ func (w *KafkaOpsRequestCustomWebhook) validateKafkaStorageMigrationOpsRequest(r
 	}
 
 	m := req.Spec.Migration
+	if m == nil {
+		return errors.New("spec.migration is required for StorageMigration type")
+	}
 	if m.Node == nil && m.Controller == nil && m.Broker == nil {
 		return errors.New("at least one of spec.migration.node, spec.migration.controller, or spec.migration.broker is required")
 	}

--- a/pkg/webhooks/ops/v1alpha1/mariadb.go
+++ b/pkg/webhooks/ops/v1alpha1/mariadb.go
@@ -189,8 +189,8 @@ func (w *MariaDBOpsRequestCustomWebhook) validateMariaDBStorageMigrationOpsReque
 	if req.Spec.Timeout == nil {
 		return errors.New("spec.timeout is required for Storage Migration ops request, adjust timeout according to the size of your database")
 	}
-	if db.Spec.Storage == nil {
-		return nil
+	if db.Spec.Storage == nil || db.Spec.Storage.StorageClassName == nil {
+		return fmt.Errorf("db.Spec.Storage.StorageClassName can't be nil in the database yaml")
 	}
 	var newstorage, oldstorage storagev1.StorageClass
 	if err := w.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: *m.StorageClassName}, &newstorage); err != nil {

--- a/pkg/webhooks/ops/v1alpha1/mssqlserver.go
+++ b/pkg/webhooks/ops/v1alpha1/mssqlserver.go
@@ -201,8 +201,8 @@ func (w *MSSQLServerOpsRequestCustomWebhook) validateMSSQLServerStorageMigration
 	if req.Spec.Timeout == nil {
 		return errors.New("spec.timeout is required for Storage Migration ops request, adjust timeout according to the size of your database")
 	}
-	if db.Spec.Storage == nil {
-		return nil
+	if db.Spec.Storage == nil || db.Spec.Storage.StorageClassName == nil {
+		return fmt.Errorf("db.Spec.Storage.StorageClassName can't be nil in the database yaml")
 	}
 	var newstorage, oldstorage storagev1.StorageClass
 	if err := w.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: *m.StorageClassName}, &newstorage); err != nil {

--- a/pkg/webhooks/ops/v1alpha1/postgres.go
+++ b/pkg/webhooks/ops/v1alpha1/postgres.go
@@ -343,6 +343,9 @@ func (w *PostgresOpsRequestCustomWebhook) validatePostgresStorageMigrationOpsReq
 		return errors.Wrap(err, fmt.Sprintf("failed to get postgres: %s/%s", req.Namespace, req.Spec.DatabaseRef.Name))
 	}
 
+	if req.Spec.Migration == nil {
+		return errors.New("spec.migration is required for StorageMigration type")
+	}
 	if req.Spec.Migration.StorageClassName == nil {
 		return errors.New("spec.migration.storageClassName is required")
 	}
@@ -350,6 +353,9 @@ func (w *PostgresOpsRequestCustomWebhook) validatePostgresStorageMigrationOpsReq
 		// timeout is required for Storage Migration ops request because it's a long-running operation
 		// default timeout is len(pods) * 5 minute
 		return errors.New("spec.timeout is required for Storage Migration ops request,adjust timeout according to the size of your database")
+	}
+	if db.Spec.Storage == nil || db.Spec.Storage.StorageClassName == nil {
+		return fmt.Errorf("db.Spec.Storage.StorageClassName can't be nil in the database yaml")
 	}
 	// check new storageClass
 	var newstorage, oldstorage storagev1.StorageClass

--- a/pkg/webhooks/ops/v1alpha1/rabbitmq.go
+++ b/pkg/webhooks/ops/v1alpha1/rabbitmq.go
@@ -213,8 +213,8 @@ func (rv *RabbitMQOpsRequestCustomWebhook) validateRabbitMQStorageMigrationOpsRe
 	if req.Spec.Timeout == nil {
 		return errors.New("spec.timeout is required for Storage Migration ops request, adjust timeout according to the size of your database")
 	}
-	if db.Spec.Storage == nil {
-		return nil
+	if db.Spec.Storage == nil || db.Spec.Storage.StorageClassName == nil {
+		return fmt.Errorf("db.Spec.Storage.StorageClassName can't be nil in the database yaml")
 	}
 	var newstorage, oldstorage storagev1.StorageClass
 	if err := rv.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: *m.StorageClassName}, &newstorage); err != nil {

--- a/pkg/webhooks/ops/v1alpha1/redis.go
+++ b/pkg/webhooks/ops/v1alpha1/redis.go
@@ -223,8 +223,8 @@ func (w *RedisOpsRequestCustomWebhook) validateRedisStorageMigrationOpsRequest(r
 	if req.Spec.Timeout == nil {
 		return errors.New("spec.timeout is required for Storage Migration ops request, adjust timeout according to the size of your database")
 	}
-	if db.Spec.Storage == nil {
-		return nil
+	if db.Spec.Storage == nil || db.Spec.Storage.StorageClassName == nil {
+		return fmt.Errorf("db.Spec.Storage.StorageClassName can't be nil in the database yaml")
 	}
 	var newstorage, oldstorage storagev1.StorageClass
 	if err := w.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: *m.StorageClassName}, &newstorage); err != nil {


### PR DESCRIPTION
## Summary

- Add missing `spec.migration == nil` guard before field access in `kafka.go`, `elasticsearch.go`, `druid.go`, and `postgres.go` webhooks
- Replace silent `return nil` on `db.Spec.Storage == nil` with a combined check for `db.Spec.Storage.StorageClassName == nil`, preventing a nil dereference when the storage class name is subsequently dereferenced — affects `mariadb.go`, `mssqlserver.go`, `ignite.go`, `hazelcast.go`, `cassandra.go`, `redis.go`, `rabbitmq.go`, and `postgres.go`

## Test plan

- [ ] Apply a `StorageMigration` ops request with `spec.migration` omitted and verify the webhook returns a validation error instead of panicking
- [ ] Apply a `StorageMigration` ops request against a database with no `spec.storage.storageClassName` set and verify the webhook returns the descriptive error message
- [ ] Apply a valid `StorageMigration` ops request and verify it is still accepted by the webhook

🤖 Generated with [Claude Code](https://claude.com/claude-code)