### PR TITLE
Experimental: Makefile: speed up code generation with shared build cache and parall…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       # compiled package/type-check results across runs instead of recompiling
       # the entire k8s dependency tree from scratch every time.
       - name: Cache Go build cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             .go/cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,21 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      # Persist the Go build cache that all dockerized make targets share via
+      # the in-repo .go/cache mount. This lets `make gen`/build/lint/test reuse
+      # compiled package/type-check results across runs instead of recompiling
+      # the entire k8s dependency tree from scratch every time.
+      - name: Cache Go build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .go/cache
+            .go/bin
+          key: ${{ runner.os }}-go-cache-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-go-cache-${{ hashFiles('**/go.sum') }}-
+            ${{ runner.os }}-go-cache-
+
       - name: Run checks
         run: |
           make ci

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,14 @@ CODE_GENERATOR_IMAGE ?= ghcr.io/appscode/gengo:release-1.32
 CORE_API_GROUPS      ?= kubedb:v1alpha1 kubedb:v1alpha2 kubedb:v1 gitops:v1alpha1 postgres:v1alpha1 catalog:v1alpha1 config:v1alpha1 ops:v1alpha1 autoscaling:v1alpha1 elasticsearch:v1alpha1 schema:v1alpha1 archiver:v1alpha1 kafka:v1alpha1 migrator:v1alpha1
 API_GROUPS           ?= $(CORE_API_GROUPS) ui:v1alpha1
 
+# Number of parallel jobs used to fan out per-group code generation.
+NPROC                ?= $(shell nproc 2>/dev/null || echo 2)
+# openapi-gen writes its API-rule violations to a single shared report file.
+# Generating groups serially, the last group in API_GROUPS "wins" that file.
+# To keep output identical when generating in parallel, only the last group
+# writes the canonical report; every other group writes a throwaway report.
+OPENAPI_LAST_GROUP   := $(subst :,_,$(lastword $(API_GROUPS)))
+
 # This version-strategy uses git tags to set the version string
 git_branch       := $(shell git rev-parse --abbrev-ref HEAD)
 git_tag          := $(shell git describe --tags --exact-match --abbrev=0 2>/dev/null || echo "")
@@ -106,10 +114,10 @@ DOCKER_REPO_ROOT := /go/src/$(GO_PKG)/$(REPO)
 
 # Generate a typed clientset
 .PHONY: clientset
-clientset:
+clientset: $(BUILD_DIRS)
 	@docker run --rm	                                 \
 		-u $$(id -u):$$(id -g)                           \
-		-v /tmp:/.cache                                  \
+		-v $$(pwd)/.go/cache:/.cache                     \
 		-v $$(pwd):$(DOCKER_REPO_ROOT)                   \
 		-w $(DOCKER_REPO_ROOT)                           \
 		--env HTTP_PROXY=$(HTTP_PROXY)                   \
@@ -123,10 +131,10 @@ clientset:
 			--go-header-file "./hack/license/go.txt"
 
 .PHONY: gen-conversion
-gen-conversion:
+gen-conversion: $(BUILD_DIRS)
 	@docker run --rm                                   \
 		-u $$(id -u):$$(id -g)                           \
-		-v /tmp:/.cache                                  \
+		-v $$(pwd)/.go/cache:/.cache                     \
 		-v $$(pwd):$(DOCKER_REPO_ROOT)                   \
 		-w $(DOCKER_REPO_ROOT)                           \
 		--env HTTP_PROXY=$(HTTP_PROXY)                   \
@@ -139,11 +147,12 @@ gen-conversion:
 
 # Generate openapi schema
 .PHONY: openapi
-openapi: $(addprefix openapi-, $(subst :,_, $(API_GROUPS)))
+openapi: $(BUILD_DIRS)
+	@$(MAKE) --no-print-directory -j$(NPROC) $(addprefix openapi-, $(subst :,_, $(API_GROUPS)))
 	@echo "Generating openapi/swagger.json"
 	@docker run --rm	                                 \
 		-u $$(id -u):$$(id -g)                           \
-		-v /tmp:/.cache                                  \
+		-v $$(pwd)/.go/cache:/.cache                     \
 		-v $$(pwd):$(DOCKER_REPO_ROOT)                   \
 		-w $(DOCKER_REPO_ROOT)                           \
 		--env HTTP_PROXY=$(HTTP_PROXY)                   \
@@ -153,12 +162,12 @@ openapi: $(addprefix openapi-, $(subst :,_, $(API_GROUPS)))
 		$(BUILD_IMAGE)                                   \
 		go run hack/gencrd/main.go
 
-openapi-%:
+openapi-%: $(BUILD_DIRS)
 	@echo "Generating openapi schema for $(subst _,/,$*)"
-	@mkdir -p .config/api-rules
+	@mkdir -p .config/api-rules bin
 	@docker run --rm	                                 \
 		-u $$(id -u):$$(id -g)                           \
-		-v /tmp:/.cache                                  \
+		-v $$(pwd)/.go/cache:/.cache                     \
 		-v $$(pwd):$(DOCKER_REPO_ROOT)                   \
 		-w $(DOCKER_REPO_ROOT)                           \
 		--env HTTP_PROXY=$(HTTP_PROXY)                   \
@@ -169,15 +178,15 @@ openapi-%:
 			--go-header-file "./hack/license/go.txt" \
 			--input-dirs "$(GO_PKG)/$(REPO)/apis/$(subst _,/,$*),k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/apimachinery/pkg/api/resource,k8s.io/apimachinery/pkg/runtime,k8s.io/apimachinery/pkg/util/intstr,k8s.io/apimachinery/pkg/version,k8s.io/api/core/v1,k8s.io/api/apps/v1,kmodules.xyz/offshoot-api/api/v1,kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1,kmodules.xyz/monitoring-agent-api/api/v1,k8s.io/api/rbac/v1,k8s.io/api/autoscaling/v2beta2,kmodules.xyz/objectstore-api/api/v1,kmodules.xyz/client-go/api/v1,k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1,github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1" \
 			--output-package "$(GO_PKG)/$(REPO)/apis/$(subst _,/,$*)" \
-			--report-filename .config/api-rules/violation_exceptions.list
+			--report-filename $(if $(filter $(OPENAPI_LAST_GROUP),$*),.config/api-rules/violation_exceptions.list,bin/violation_exceptions.$*.list)
 
 # Generate CRD manifests
 .PHONY: gen-crds
-gen-crds:
+gen-crds: $(BUILD_DIRS)
 	@echo "Generating CRD manifests"
 	@docker run --rm	                    \
 		-u $$(id -u):$$(id -g)              \
-		-v /tmp:/.cache                     \
+		-v $$(pwd)/.go/cache:/.cache                     \
 		-v $$(pwd):$(DOCKER_REPO_ROOT)      \
 		-w $(DOCKER_REPO_ROOT)              \
 	    --env HTTP_PROXY=$(HTTP_PROXY)      \
@@ -233,11 +242,11 @@ gen-crd-protos: $(addprefix gen-crd-protos-, $(subst :,_, $(CORE_API_GROUPS))) g
 	@rm -rf vendor/sigs.k8s.io/controller-runtime/pkg/scheme/generated.pb.go
 	@rm -rf vendor/sigs.k8s.io/controller-runtime/pkg/scheme/generated.proto
 
-gen-crd-protos-%:
+gen-crd-protos-%: $(BUILD_DIRS)
 	@echo "Generating protobuf for $(subst _,/,$*)"
 	@docker run --rm                                     \
 		-u $$(id -u):$$(id -g)                           \
-		-v /tmp:/.cache                                  \
+		-v $$(pwd)/.go/cache:/.cache                     \
 		-v $$(pwd):$(DOCKER_REPO_ROOT)                   \
 		-w $(DOCKER_REPO_ROOT)                           \
 		--env HTTP_PROXY=$(HTTP_PROXY)                   \
@@ -251,11 +260,11 @@ gen-crd-protos-%:
 			--packages=+sigs.k8s.io/controller-runtime/pkg/scheme,-k8s.io/api/core/v1,-k8s.io/api/apps/v1,-k8s.io/api/autoscaling/v2beta2,-kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1,-kmodules.xyz/monitoring-agent-api/api/v1,-kmodules.xyz/objectstore-api/api/v1,-kmodules.xyz/offshoot-api/api/v1,-kmodules.xyz/client-go/api/v1,kubedb.dev/apimachinery/apis/$(subst _,/,$*)
 
 .PHONY: gen-crd-protos-ui-v1alpha1
-gen-crd-protos-ui-v1alpha1:
+gen-crd-protos-ui-v1alpha1: $(BUILD_DIRS)
 	@echo "Generating protobuf for ui/v1alpha1"
 	@docker run --rm                                     \
 		-u $$(id -u):$$(id -g)                           \
-		-v /tmp:/.cache                                  \
+		-v $$(pwd)/.go/cache:/.cache                     \
 		-v $$(pwd):$(DOCKER_REPO_ROOT)                   \
 		-w $(DOCKER_REPO_ROOT)                           \
 		--env HTTP_PROXY=$(HTTP_PROXY)                   \
@@ -406,11 +415,11 @@ verify-gen: gen fmt
 	fi
 
 .PHONY: add-license
-add-license:
+add-license: $(BUILD_DIRS)
 	@echo "Adding license header"
 	@docker run --rm 	                                 \
 		-u $$(id -u):$$(id -g)                           \
-		-v /tmp:/.cache                                  \
+		-v $$(pwd)/.go/cache:/.cache                     \
 		-v $$(pwd):$(DOCKER_REPO_ROOT)                   \
 		-w $(DOCKER_REPO_ROOT)                           \
 		--env HTTP_PROXY=$(HTTP_PROXY)                   \
@@ -419,11 +428,11 @@ add-license:
 		ltag -t "./hack/license" --excludes ".go vendor contrib libbuild" -v
 
 .PHONY: check-license
-check-license:
+check-license: $(BUILD_DIRS)
 	@echo "Checking files for license header"
 	@docker run --rm 	                                 \
 		-u $$(id -u):$$(id -g)                           \
-		-v /tmp:/.cache                                  \
+		-v $$(pwd)/.go/cache:/.cache                     \
 		-v $$(pwd):$(DOCKER_REPO_ROOT)                   \
 		-w $(DOCKER_REPO_ROOT)                           \
 		--env HTTP_PROXY=$(HTTP_PROXY)                   \


### PR DESCRIPTION
…el openapi

Mount the persistent in-repo .go/cache as the Go build cache for every dockerized generator (clientset, conversion, openapi, crds, protos, license) instead of the ephemeral /tmp, matching what build/test/lint already use. This lets generators reuse compiled/type-checked packages across runs instead of recompiling the k8s dependency tree from scratch. Add $(BUILD_DIRS) prereqs so the cache dir exists before docker mounts it, and cache .go/cache across CI runs via actions/cache.

Fan out the 15 per-group openapi-% targets with make -j$(NPROC) so they reuse the warm cache. openapi-gen writes API-rule violations to a single shared report file where the last group in API_GROUPS wins; to keep output identical under parallelism, only the last group writes the canonical violation_exceptions.list while others write throwaway reports under bin/.