### PR TITLE
Add Aerospike feature gate and register AerospikeVersion in scheme

### DIFF
--- a/apis/catalog/v1alpha1/register.go
+++ b/apis/catalog/v1alpha1/register.go
@@ -54,6 +54,8 @@ func Resource(resource string) schema.GroupResource {
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
+		&AerospikeVersion{},
+		&AerospikeVersionList{},
 		&CassandraVersion{},
 		&CassandraVersionList{},
 		&ClickHouseVersion{},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -31,6 +31,9 @@ const (
 	// of code conflicts because changes are more likely to be scattered
 	// across the file.
 
+	// Enables Aerospike operator.
+	Aerospike featuregate.Feature = "Aerospike"
+
 	// Enables Cassandra operator.
 	Cassandra featuregate.Feature = "Cassandra"
 
@@ -160,6 +163,7 @@ func init() {
 // To add a new feature, define a key for it above and add it here. The features will be
 // available throughout KubeDB binaries.
 var defaultKubeDBFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	Aerospike:  {Default: false, PreRelease: featuregate.Alpha},
 	Cassandra:  {Default: false, PreRelease: featuregate.Alpha},
 	ClickHouse: {Default: false, PreRelease: featuregate.Alpha},
 	DB2:        {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
## What

While reviewing the Aerospike support against how other databases are wired (using the DocumentDB PR #1604 as a reference for the new-database checklist), two common wiring steps were missing:

1. **Feature gate** (`pkg/features/features.go`): Aerospike had no feature gate. Added the `Aerospike` feature const and its default `FeatureSpec` (`{Default: false, PreRelease: Alpha}`), matching every other database, so the operator can be enabled/disabled via feature gates.

2. **Catalog scheme registration** (`apis/catalog/v1alpha1/register.go`): `AerospikeVersion` and `AerospikeVersionList` types existed but were never added to `addKnownTypes`, so they were not registered with the scheme. Added them.

Both entries are placed alphabetically (before `Cassandra`), consistent with the surrounding code and the existing `Aerospike` registration in `apis/kubedb/v1alpha2/register.go`.

## Notes

- Generated files and `client/` were intentionally not touched.
- The existing webhook (`pkg/webhooks/kubedb/v1alpha2/aerospike.go`) and the `kubedb/v1alpha2` scheme registration were already in place and correct.