### PR TITLE
Add cilium backup ingress policy and DNS egress for backup jobs

### DIFF
--- a/pkg/network_policy/cilium.go
+++ b/pkg/network_policy/cilium.go
@@ -48,6 +48,9 @@ func ensureCiliumPolicies(kbClient client.Client, dbNs string) error {
 	if err := ensureCiliumKubeAPIPolicy(kbClient, dbNs); err != nil {
 		return err
 	}
+	if err := ensureCiliumBackupIngressPolicy(kbClient, dbNs); err != nil {
+		return err
+	}
 	return ensureCiliumBackupPolicy(kbClient, dbNs)
 }
 
@@ -169,6 +172,28 @@ func ensureCiliumKubeAPIPolicy(kbClient client.Client, dbNs string) error {
 	return ensureCiliumNetworkPolicy(kbClient, dbNs, "kubedb-kube-apiserver", spec)
 }
 
+// ensureCiliumBackupIngressPolicy allows kubestash-managed pods (backup/restore
+// jobs) to reach the DB pods on the ingress side.
+func ensureCiliumBackupIngressPolicy(kbClient client.Client, dbNs string) error {
+	spec := map[string]any{
+		"endpointSelector": map[string]any{
+			"matchLabels": stringMapToInterface(api.GetSelectorForNetworkPolicy()),
+		},
+		"ingress": []any{
+			map[string]any{
+				"fromEndpoints": []any{
+					map[string]any{
+						"matchLabels": map[string]any{
+							"k8s:" + meta_util.ManagedByLabelKey: kubestashapi.KubeStashKey,
+						},
+					},
+				},
+			},
+		},
+	}
+	return ensureCiliumNetworkPolicy(kbClient, dbNs, NetworkPolicyNameDBBackupIngress, spec)
+}
+
 func ensureCiliumBackupPolicy(kbClient client.Client, dbNs string) error {
 	spec := map[string]any{
 		"endpointSelector": map[string]any{
@@ -190,6 +215,38 @@ func ensureCiliumBackupPolicy(kbClient client.Client, dbNs string) error {
 			// Reach object storage / external endpoints.
 			map[string]any{
 				"toEntities": []any{"world"},
+			},
+			// DNS egress to kube-dns so backup jobs can resolve service names.
+			map[string]any{
+				"toEndpoints": []any{
+					map[string]any{
+						"matchLabels": map[string]any{
+							"k8s:io.kubernetes.pod.namespace": "kube-system",
+							"k8s:k8s-app":                     "kube-dns",
+						},
+					},
+				},
+				"toPorts": []any{
+					map[string]any{
+						"ports": []any{
+							map[string]any{
+								"port":     "53",
+								"protocol": "UDP",
+							},
+							map[string]any{
+								"port":     "53",
+								"protocol": "TCP",
+							},
+						},
+						"rules": map[string]any{
+							"dns": []any{
+								map[string]any{
+									"matchPattern": "*",
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}

--- a/pkg/network_policy/cilium.go
+++ b/pkg/network_policy/cilium.go
@@ -212,11 +212,15 @@ func ensureCiliumBackupPolicy(kbClient client.Client, dbNs string) error {
 					},
 				},
 			},
-			// Reach object storage: "world" for external endpoints, "cluster"
-			// for in-cluster backends (e.g. an in-cluster MinIO in another
-			// namespace) which "world" does not cover.
+			// Reach external object storage endpoints.
 			map[string]any{
-				"toEntities": []any{"world", "cluster"},
+				"toEntities": []any{"world"},
+			},
+			// Reach in-cluster object storage (e.g. an in-cluster MinIO in
+			// another namespace), which "world" does not cover. Kept as a
+			// separate rule since Cilium does not accept both entities in one.
+			map[string]any{
+				"toEntities": []any{"cluster"},
 			},
 			// DNS egress to kube-dns so backup jobs can resolve service names.
 			map[string]any{

--- a/pkg/network_policy/cilium.go
+++ b/pkg/network_policy/cilium.go
@@ -212,9 +212,11 @@ func ensureCiliumBackupPolicy(kbClient client.Client, dbNs string) error {
 					},
 				},
 			},
-			// Reach object storage / external endpoints.
+			// Reach object storage: "world" for external endpoints, "cluster"
+			// for in-cluster backends (e.g. an in-cluster MinIO in another
+			// namespace) which "world" does not cover.
 			map[string]any{
-				"toEntities": []any{"world"},
+				"toEntities": []any{"world", "cluster"},
 			},
 			// DNS egress to kube-dns so backup jobs can resolve service names.
 			map[string]any{

--- a/pkg/network_policy/network_policy.go
+++ b/pkg/network_policy/network_policy.go
@@ -40,9 +40,10 @@ const (
 )
 
 const (
-	NetworkPolicyNameHealthCheck = "kubedb-healthcheck"
-	NetworkPolicyNameDBInternal  = "kubedb-database-internal"
-	NetworkPolicyNameDBBackup    = "kubedb-database-backup"
+	NetworkPolicyNameHealthCheck     = "kubedb-healthcheck"
+	NetworkPolicyNameDBInternal      = "kubedb-database-internal"
+	NetworkPolicyNameDBBackup        = "kubedb-database-backup"
+	NetworkPolicyNameDBBackupIngress = "kubedb-database-backup-ingress"
 )
 
 // EnsureNetworkPolicy emits the default (FlavorKubernetes) per-DB-namespace


### PR DESCRIPTION
## Changes

In `pkg/network_policy/cilium.go`:

1. **New** `CiliumNetworkPolicy` `kubedb-database-backup-ingress` — allows kubestash-managed pods (backup/restore jobs) to reach DB pods on the ingress side.
2. **Modified** `kubedb-database-backup` egress policy — added DNS egress to `kube-system/kube-dns` (port 53 UDP+TCP, `dns: matchPattern '*'`) so backup jobs can resolve service names.