### PR TITLE
Set default container resizePolicy for all databases

### DIFF
--- a/apis/helpers.go
+++ b/apis/helpers.go
@@ -35,6 +35,22 @@ type ResourceInfo interface {
 	CustomResourceDefinition() *apiextensions.CustomResourceDefinition
 }
 
+// SetDefaultResizePolicy sets a NotRequired in-place resize policy for cpu & memory
+// on every passed container whose ResizePolicy is not already set.
+func SetDefaultResizePolicy(containers ...[]core.Container) {
+	for _, list := range containers {
+		for i := range list {
+			if list[i].ResizePolicy != nil {
+				continue
+			}
+			list[i].ResizePolicy = []core.ContainerResizePolicy{
+				{ResourceName: core.ResourceCPU, RestartPolicy: core.NotRequired},
+				{ResourceName: core.ResourceMemory, RestartPolicy: core.NotRequired},
+			}
+		}
+	}
+}
+
 func SetDefaultResourceLimits(req *core.ResourceRequirements, defaultResources core.ResourceRequirements) {
 	// if request is set,
 	//		- limit set:

--- a/apis/kubedb/v1/elasticsearch_helpers.go
+++ b/apis/kubedb/v1/elasticsearch_helpers.go
@@ -488,6 +488,7 @@ func (e *Elasticsearch) SetDefaults(esVersion *catalog.ElasticsearchVersion) {
 		if dbContainer != nil {
 			apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResourcesMemoryIntensive)
 		}
+		apis.SetDefaultResizePolicy(e.Spec.Topology.Ingest.PodTemplate.Spec.Containers, e.Spec.Topology.Ingest.PodTemplate.Spec.InitContainers)
 		if e.Spec.Topology.Ingest.Replicas == nil {
 			e.Spec.Topology.Ingest.Replicas = pointer.Int32P(1)
 		}
@@ -506,6 +507,7 @@ func (e *Elasticsearch) SetDefaults(esVersion *catalog.ElasticsearchVersion) {
 		if dbContainer != nil {
 			apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResourcesMemoryIntensive)
 		}
+		apis.SetDefaultResizePolicy(e.Spec.Topology.Master.PodTemplate.Spec.Containers, e.Spec.Topology.Master.PodTemplate.Spec.InitContainers)
 		if e.Spec.Topology.Master.Replicas == nil {
 			e.Spec.Topology.Master.Replicas = pointer.Int32P(1)
 		}
@@ -526,6 +528,7 @@ func (e *Elasticsearch) SetDefaults(esVersion *catalog.ElasticsearchVersion) {
 			if dbContainer != nil {
 				apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResourcesMemoryIntensive)
 			}
+			apis.SetDefaultResizePolicy(e.Spec.Topology.Data.PodTemplate.Spec.Containers, e.Spec.Topology.Data.PodTemplate.Spec.InitContainers)
 			if e.Spec.Topology.Data.Replicas == nil {
 				e.Spec.Topology.Data.Replicas = pointer.Int32P(1)
 			}
@@ -546,6 +549,7 @@ func (e *Elasticsearch) SetDefaults(esVersion *catalog.ElasticsearchVersion) {
 			if dbContainer != nil {
 				apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResourcesMemoryIntensive)
 			}
+			apis.SetDefaultResizePolicy(e.Spec.Topology.DataHot.PodTemplate.Spec.Containers, e.Spec.Topology.DataHot.PodTemplate.Spec.InitContainers)
 			if e.Spec.Topology.DataHot.Replicas == nil {
 				e.Spec.Topology.DataHot.Replicas = pointer.Int32P(1)
 			}
@@ -566,6 +570,7 @@ func (e *Elasticsearch) SetDefaults(esVersion *catalog.ElasticsearchVersion) {
 			if dbContainer != nil {
 				apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResourcesMemoryIntensive)
 			}
+			apis.SetDefaultResizePolicy(e.Spec.Topology.DataWarm.PodTemplate.Spec.Containers, e.Spec.Topology.DataWarm.PodTemplate.Spec.InitContainers)
 			if e.Spec.Topology.DataWarm.Replicas == nil {
 				e.Spec.Topology.DataWarm.Replicas = pointer.Int32P(1)
 			}
@@ -586,6 +591,7 @@ func (e *Elasticsearch) SetDefaults(esVersion *catalog.ElasticsearchVersion) {
 			if dbContainer != nil {
 				apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResourcesMemoryIntensive)
 			}
+			apis.SetDefaultResizePolicy(e.Spec.Topology.DataCold.PodTemplate.Spec.Containers, e.Spec.Topology.DataCold.PodTemplate.Spec.InitContainers)
 			if e.Spec.Topology.DataCold.Replicas == nil {
 				e.Spec.Topology.DataCold.Replicas = pointer.Int32P(1)
 			}
@@ -606,6 +612,7 @@ func (e *Elasticsearch) SetDefaults(esVersion *catalog.ElasticsearchVersion) {
 			if dbContainer != nil {
 				apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResourcesMemoryIntensive)
 			}
+			apis.SetDefaultResizePolicy(e.Spec.Topology.DataFrozen.PodTemplate.Spec.Containers, e.Spec.Topology.DataFrozen.PodTemplate.Spec.InitContainers)
 			if e.Spec.Topology.DataFrozen.Replicas == nil {
 				e.Spec.Topology.DataFrozen.Replicas = pointer.Int32P(1)
 			}
@@ -626,6 +633,7 @@ func (e *Elasticsearch) SetDefaults(esVersion *catalog.ElasticsearchVersion) {
 			if dbContainer != nil {
 				apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResourcesMemoryIntensive)
 			}
+			apis.SetDefaultResizePolicy(e.Spec.Topology.DataContent.PodTemplate.Spec.Containers, e.Spec.Topology.DataContent.PodTemplate.Spec.InitContainers)
 			if e.Spec.Topology.DataContent.Replicas == nil {
 				e.Spec.Topology.DataContent.Replicas = pointer.Int32P(1)
 			}
@@ -646,6 +654,7 @@ func (e *Elasticsearch) SetDefaults(esVersion *catalog.ElasticsearchVersion) {
 			if dbContainer != nil {
 				apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResourcesMemoryIntensive)
 			}
+			apis.SetDefaultResizePolicy(e.Spec.Topology.ML.PodTemplate.Spec.Containers, e.Spec.Topology.ML.PodTemplate.Spec.InitContainers)
 			if e.Spec.Topology.ML.Replicas == nil {
 				e.Spec.Topology.ML.Replicas = pointer.Int32P(1)
 			}
@@ -666,6 +675,7 @@ func (e *Elasticsearch) SetDefaults(esVersion *catalog.ElasticsearchVersion) {
 			if dbContainer != nil {
 				apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResourcesMemoryIntensive)
 			}
+			apis.SetDefaultResizePolicy(e.Spec.Topology.Transform.PodTemplate.Spec.Containers, e.Spec.Topology.Transform.PodTemplate.Spec.InitContainers)
 			if e.Spec.Topology.Transform.Replicas == nil {
 				e.Spec.Topology.Transform.Replicas = pointer.Int32P(1)
 			}
@@ -681,6 +691,7 @@ func (e *Elasticsearch) SetDefaults(esVersion *catalog.ElasticsearchVersion) {
 		if dbContainer != nil {
 			apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResourcesMemoryIntensive)
 		}
+		apis.SetDefaultResizePolicy(e.Spec.PodTemplate.Spec.Containers, e.Spec.PodTemplate.Spec.InitContainers)
 		if e.Spec.Replicas == nil {
 			e.Spec.Replicas = pointer.Int32P(1)
 		}

--- a/apis/kubedb/v1/kafka_helpers.go
+++ b/apis/kubedb/v1/kafka_helpers.go
@@ -474,6 +474,8 @@ func (k *Kafka) setDefaultContainerSecurityContext(kfVersion *catalog.KafkaVersi
 		k.assignDefaultContainerSecurityContext(kfVersion, initContainer.SecurityContext)
 		podTemplate.Spec.InitContainers = coreutil.UpsertContainer(podTemplate.Spec.InitContainers, *initContainer)
 	}
+
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (k *Kafka) assignDefaultContainerSecurityContext(kfVersion *catalog.KafkaVersion, sc *core.SecurityContext) {

--- a/apis/kubedb/v1/mariadb_helpers.go
+++ b/apis/kubedb/v1/mariadb_helpers.go
@@ -534,6 +534,7 @@ func (m *MariaDB) setDefaultContainerResourceLimits(podTemplate *ofstv2.PodTempl
 			apis.SetDefaultResourceLimits(&coordinatorContainer.Resources, kubedb.CoordinatorDefaultResources)
 		}
 	}
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (m *MariaDB) setMaxscaleDefaultContainerResourceLimits(podTemplate *ofstv2.PodTemplateSpec) {
@@ -546,6 +547,7 @@ func (m *MariaDB) setMaxscaleDefaultContainerResourceLimits(podTemplate *ofstv2.
 	if initContainer != nil && (initContainer.Resources.Requests == nil && initContainer.Resources.Limits == nil) {
 		apis.SetDefaultResourceLimits(&initContainer.Resources, kubedb.DefaultInitContainerResource)
 	}
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (m *MariaDB) SetHealthCheckerDefaults() {

--- a/apis/kubedb/v1/memcached_helpers.go
+++ b/apis/kubedb/v1/memcached_helpers.go
@@ -298,6 +298,7 @@ func (m *Memcached) setDefaultContainerResourceLimits(podTemplate *ofstv2.PodTem
 	if dbContainer != nil {
 		apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResources)
 	}
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 // CertificateName returns the default certificate name and/or certificate secret name for a certificate alias

--- a/apis/kubedb/v1/mongodb_helpers.go
+++ b/apis/kubedb/v1/mongodb_helpers.go
@@ -774,6 +774,8 @@ func (m *MongoDB) setPodTemplateDefaultValues(podTemplate *ofstv2.PodTemplateSpe
 		container = ofst_util.EnsureContainerExists(podTemplate, kubedb.ReplicationModeDetectorContainerName)
 		m.setContainerDefaultValues(container, mgVersion, kubedb.CoordinatorDefaultResources, isArbiter...)
 	}
+
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (m *MongoDB) setContainerDefaultValues(container *core.Container, mgVersion *v1alpha1.MongoDBVersion,

--- a/apis/kubedb/v1/mysql_helpers.go
+++ b/apis/kubedb/v1/mysql_helpers.go
@@ -356,6 +356,8 @@ func (m *MySQL) SetDefaults(myVersion *v1alpha1.MySQLVersion) error {
 			if routerContainer != nil && (routerContainer.Resources.Requests == nil && routerContainer.Resources.Limits == nil) {
 				apis.SetDefaultResourceLimits(&routerContainer.Resources, kubedb.CoordinatorDefaultResources)
 			}
+
+			apis.SetDefaultResizePolicy(m.Spec.Topology.InnoDBCluster.Router.PodTemplate.Spec.Containers, m.Spec.Topology.InnoDBCluster.Router.PodTemplate.Spec.InitContainers)
 		}
 	}
 
@@ -596,6 +598,8 @@ func (m *MySQL) setDefaultContainerResourceLimits(podTemplate *ofstv2.PodTemplat
 			apis.SetDefaultResourceLimits(&coordinatorContainer.Resources, kubedb.CoordinatorDefaultResources)
 		}
 	}
+
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (m *MySQL) ConfigSecretName() string {

--- a/apis/kubedb/v1/perconaxtradb_helpers.go
+++ b/apis/kubedb/v1/perconaxtradb_helpers.go
@@ -338,6 +338,8 @@ func (p *PerconaXtraDB) setDefaultContainerResourceLimits(podTemplate *ofstv2.Po
 	if coordinatorContainer != nil && (coordinatorContainer.Resources.Requests == nil && coordinatorContainer.Resources.Limits == nil) {
 		apis.SetDefaultResourceLimits(&coordinatorContainer.Resources, kubedb.CoordinatorDefaultResources)
 	}
+
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (p *PerconaXtraDB) SetHealthCheckerDefaults() {

--- a/apis/kubedb/v1/pgbouncer_helpers.go
+++ b/apis/kubedb/v1/pgbouncer_helpers.go
@@ -268,6 +268,7 @@ func (p *PgBouncer) setPgBouncerContainerDefaults(podTemplate *ofstv2.PodTemplat
 	container := ofst_util.EnsureContainerExists(podTemplate, kubedb.PgBouncerContainerName)
 	p.setContainerDefaultResources(container, *kubedb.DefaultResources.DeepCopy())
 	p.SetContainerDefaultSecurityContext(container, pbVersion)
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (p *PgBouncer) setContainerDefaultResources(container *core.Container, defaultResources core.ResourceRequirements) {

--- a/apis/kubedb/v1/postgres_helpers.go
+++ b/apis/kubedb/v1/postgres_helpers.go
@@ -405,6 +405,7 @@ func (p *Postgres) SetDefaults(postgresVersion *catalog.PostgresVersion) {
 	p.SetPostgresContainerDefaults(&p.Spec.PodTemplate, postgresVersion)
 	p.SetCoordinatorContainerDefaults(&p.Spec.PodTemplate, postgresVersion)
 	p.SetInitContainerDefaults(&p.Spec.PodTemplate, postgresVersion)
+	apis.SetDefaultResizePolicy(p.Spec.PodTemplate.Spec.Containers, p.Spec.PodTemplate.Spec.InitContainers)
 
 	// Need to set FSGroup equal to  p.Spec.PodTemplate.Spec.ContainerSecurityContext.RunAsGroup.
 	// So that /var/pv directory have the group permission for the RunAsGroup user GID.

--- a/apis/kubedb/v1/proxysql_helpers.go
+++ b/apis/kubedb/v1/proxysql_helpers.go
@@ -245,6 +245,8 @@ func (p *ProxySQL) SetDefaults(psVersion *v1alpha1.ProxySQLVersion, usesAcme boo
 	if dbContainer != nil {
 		apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResources)
 	}
+
+	apis.SetDefaultResizePolicy(p.Spec.PodTemplate.Spec.Containers, p.Spec.PodTemplate.Spec.InitContainers)
 }
 
 func (p *ProxySQL) setDefaultContainerSecurityContext(proxyVersion *v1alpha1.ProxySQLVersion, podTemplate *ofstv2.PodTemplateSpec) {

--- a/apis/kubedb/v1/redis_helpers.go
+++ b/apis/kubedb/v1/redis_helpers.go
@@ -445,6 +445,8 @@ func (r *Redis) setDefaultContainerResourceLimits(podTemplate *ofstv2.PodTemplat
 			apis.SetDefaultResourceLimits(&coordinatorContainer.Resources, kubedb.CoordinatorDefaultResources)
 		}
 	}
+
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (r Redis) ShardNodeTemplate() string {

--- a/apis/kubedb/v1/redis_sentinel_helpers.go
+++ b/apis/kubedb/v1/redis_sentinel_helpers.go
@@ -347,6 +347,8 @@ func (rs *RedisSentinel) setDefaultContainerResourceLimits(podTemplate *ofstv2.P
 	if initContainer != nil && (initContainer.Resources.Requests == nil && initContainer.Resources.Limits == nil) {
 		apis.SetDefaultResourceLimits(&initContainer.Resources, kubedb.DefaultInitContainerResource)
 	}
+
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 // CertificateName returns the default certificate name and/or certificate secret name for a certificate alias

--- a/apis/kubedb/v1alpha2/aerospike_helpers.go
+++ b/apis/kubedb/v1alpha2/aerospike_helpers.go
@@ -130,6 +130,7 @@ func (a *Aerospike) SetDefaults(arVersion *catalog.AerospikeVersion) {
 	}
 	apis.SetDefaultResourceLimits(&container.Resources, kubedb.DefaultResources)
 	a.Spec.PodTemplate.Spec.Containers = coreutil.UpsertContainer(a.Spec.PodTemplate.Spec.Containers, *container)
+	apis.SetDefaultResizePolicy(a.Spec.PodTemplate.Spec.Containers, a.Spec.PodTemplate.Spec.InitContainers)
 }
 
 func (a Aerospike) setDefaultContainerSecurityContext(arVersion *catalog.AerospikeVersion, podTemplate *ofst.PodTemplateSpec) {

--- a/apis/kubedb/v1alpha2/cassandra_helpers.go
+++ b/apis/kubedb/v1alpha2/cassandra_helpers.go
@@ -426,6 +426,8 @@ func (r *Cassandra) setDefaultContainerSecurityContext(csVersion *catalog.Cassan
 		initContainer.SecurityContext = &core.SecurityContext{}
 	}
 	r.assignDefaultContainerSecurityContext(csVersion, initContainer.SecurityContext)
+
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (r *Cassandra) assignDefaultContainerSecurityContext(csVersion *catalog.CassandraVersion, rc *core.SecurityContext) {

--- a/apis/kubedb/v1alpha2/clickhouse_helpers.go
+++ b/apis/kubedb/v1alpha2/clickhouse_helpers.go
@@ -401,6 +401,7 @@ func (c *ClickHouse) SetDefaults(kc client.Client) {
 			apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.ClickHouseDefaultResources)
 		}
 		c.setDefaultContainerSecurityContext(&chVersion, cluster.PodTemplate)
+		apis.SetDefaultResizePolicy(cluster.PodTemplate.Spec.Containers, cluster.PodTemplate.Spec.InitContainers)
 		c.Spec.ClusterTopology.Cluster = cluster
 
 		if c.Spec.ClusterTopology.ClickHouseKeeper != nil && !c.Spec.ClusterTopology.ClickHouseKeeper.ExternallyManaged && c.Spec.ClusterTopology.ClickHouseKeeper.Spec != nil {
@@ -420,6 +421,7 @@ func (c *ClickHouse) SetDefaults(kc client.Client) {
 			if dbContainer != nil {
 				apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResources)
 			}
+			apis.SetDefaultResizePolicy(c.Spec.ClusterTopology.ClickHouseKeeper.Spec.PodTemplate.Spec.Containers, c.Spec.ClusterTopology.ClickHouseKeeper.Spec.PodTemplate.Spec.InitContainers)
 		}
 	} else {
 		if c.Spec.Replicas == nil {
@@ -440,6 +442,7 @@ func (c *ClickHouse) SetDefaults(kc client.Client) {
 		if dbContainer != nil {
 			apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.ClickHouseDefaultResources)
 		}
+		apis.SetDefaultResizePolicy(c.Spec.PodTemplate.Spec.Containers, c.Spec.PodTemplate.Spec.InitContainers)
 	}
 	c.SetTLSDefaults()
 	c.SetHealthCheckerDefaults()

--- a/apis/kubedb/v1alpha2/db2_helpers.go
+++ b/apis/kubedb/v1alpha2/db2_helpers.go
@@ -150,6 +150,7 @@ func (d *DB2) SetDefaults(kc client.Client) {
 		klog.Errorf("Failed to get database version %s: %s", err.Error(), d.Spec.Version)
 		return
 	}
+	apis.SetDefaultResizePolicy(d.Spec.PodTemplate.Spec.Containers, d.Spec.PodTemplate.Spec.InitContainers)
 }
 
 func (d *DB2) initializePodTemplates() {

--- a/apis/kubedb/v1alpha2/documentdb_helpers.go
+++ b/apis/kubedb/v1alpha2/documentdb_helpers.go
@@ -258,6 +258,7 @@ func (d *DocumentDB) SetDefaults(_ client.Client, documentDBVersion catalogv1alp
 	d.SetInitContainerDefaults(d.Spec.PodTemplate, &documentDBVersion)
 	d.SetDocumentDBContainerDefaults(d.Spec.PodTemplate, &documentDBVersion)
 	d.SetCoordinatorContainerDefaults(d.Spec.PodTemplate, &documentDBVersion)
+	apis.SetDefaultResizePolicy(d.Spec.PodTemplate.Spec.Containers, d.Spec.PodTemplate.Spec.InitContainers)
 	d.SetDefaultReplicationMode()
 	d.SetHealthCheckerDefaults()
 }

--- a/apis/kubedb/v1alpha2/druid_helpers.go
+++ b/apis/kubedb/v1alpha2/druid_helpers.go
@@ -739,6 +739,8 @@ func (d *Druid) setDefaultContainerResourceLimits(podTemplate *ofst.PodTemplateS
 	if initContainer != nil && (initContainer.Resources.Requests == nil && initContainer.Resources.Limits == nil) {
 		apis.SetDefaultResourceLimits(&initContainer.Resources, kubedb.DefaultInitContainerResource)
 	}
+
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (d *Druid) GetPersistentSecrets() []string {

--- a/apis/kubedb/v1alpha2/hanadb_helpers.go
+++ b/apis/kubedb/v1alpha2/hanadb_helpers.go
@@ -769,6 +769,8 @@ func (h *HanaDB) setDefaultContainerResourceLimits(podTemplate *ofst.PodTemplate
 			apis.SetDefaultResourceLimits(&coordinatorContainer.Resources, kubedb.CoordinatorDefaultResources)
 		}
 	}
+
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (h *HanaDB) ReplicasAreReady(lister pslister.PetSetLister) (bool, string, error) {

--- a/apis/kubedb/v1alpha2/hazelcast_helpers.go
+++ b/apis/kubedb/v1alpha2/hazelcast_helpers.go
@@ -174,6 +174,7 @@ func (h *Hazelcast) SetDefaults(kc client.Client) {
 	h.setDefaultContainerSecurityContext(&hzVersion, &h.Spec.PodTemplate)
 	h.setDefaultContainerResourceLimits(&h.Spec.PodTemplate)
 	h.setDefaultProbes(&h.Spec.PodTemplate)
+	apis.SetDefaultResizePolicy(h.Spec.PodTemplate.Spec.Containers, h.Spec.PodTemplate.Spec.InitContainers)
 
 	if h.Spec.Monitor != nil {
 		h.Spec.Monitor.SetDefaults()

--- a/apis/kubedb/v1alpha2/ignite_helpers.go
+++ b/apis/kubedb/v1alpha2/ignite_helpers.go
@@ -140,6 +140,8 @@ func (i *Ignite) SetDefaults(kc client.Client) {
 		apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.IgniteDefaultResources)
 	}
 
+	apis.SetDefaultResizePolicy(i.Spec.PodTemplate.Spec.Containers, i.Spec.PodTemplate.Spec.InitContainers)
+
 	i.SetHealthCheckerDefaults()
 
 	i.Spec.Monitor.SetDefaults()

--- a/apis/kubedb/v1alpha2/kafka_helpers.go
+++ b/apis/kubedb/v1alpha2/kafka_helpers.go
@@ -399,6 +399,8 @@ func (k *Kafka) setDefaultContainerSecurityContext(kfVersion *catalog.KafkaVersi
 	}
 	k.assignDefaultContainerSecurityContext(kfVersion, dbContainer.SecurityContext)
 	podTemplate.Spec.Containers = coreutil.UpsertContainer(podTemplate.Spec.Containers, *dbContainer)
+
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (k *Kafka) assignDefaultContainerSecurityContext(kfVersion *catalog.KafkaVersion, sc *core.SecurityContext) {

--- a/apis/kubedb/v1alpha2/milvus_helpers.go
+++ b/apis/kubedb/v1alpha2/milvus_helpers.go
@@ -312,6 +312,7 @@ func (m *Milvus) setComponentDefaults(mvVersion *catalog.MilvusVersion, node any
 
 	m.setDefaultContainerSecurityContext(mvVersion, *podTemplate)
 	m.setDefaultContainerResourceLimits(*podTemplate)
+	apis.SetDefaultResizePolicy((*podTemplate).Spec.Containers, (*podTemplate).Spec.InitContainers)
 }
 
 func (m *Milvus) SetDefaults(kc client.Client) {
@@ -352,6 +353,7 @@ func (m *Milvus) SetDefaults(kc client.Client) {
 	} else {
 		m.setDefaultContainerSecurityContext(&mvVersion, m.Spec.PodTemplate)
 		m.setDefaultContainerResourceLimits(m.Spec.PodTemplate)
+		apis.SetDefaultResizePolicy(m.Spec.PodTemplate.Spec.Containers, m.Spec.PodTemplate.Spec.InitContainers)
 	}
 
 	m.setMetaStorageDefaults()

--- a/apis/kubedb/v1alpha2/mssqlserver_helpers.go
+++ b/apis/kubedb/v1alpha2/mssqlserver_helpers.go
@@ -558,6 +558,8 @@ func (m *MSSQLServer) setDefaultContainerResourceLimits(podTemplate *ofst.PodTem
 			apis.SetDefaultResourceLimits(&coordinatorContainer.Resources, kubedb.CoordinatorDefaultResources)
 		}
 	}
+
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (m *MSSQLServer) SetArbiterDefault() {

--- a/apis/kubedb/v1alpha2/neo4j_helpers.go
+++ b/apis/kubedb/v1alpha2/neo4j_helpers.go
@@ -166,6 +166,8 @@ func (r *Neo4j) SetDefaults(kc client.Client) {
 	if dbContainer != nil {
 		apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResourcesNeo4j)
 	}
+
+	apis.SetDefaultResizePolicy(r.Spec.PodTemplate.Spec.Containers, r.Spec.PodTemplate.Spec.InitContainers)
 }
 
 func (r *Neo4j) SetTLSDefaults() {

--- a/apis/kubedb/v1alpha2/oracle_helpers.go
+++ b/apis/kubedb/v1alpha2/oracle_helpers.go
@@ -329,12 +329,14 @@ func (o *Oracle) SetDefaults(kc client.Client) {
 		o.SetDefaultPodSecurityContext(o.Spec.DataGuard.Observer.PodTemplate, oraVersion)
 		o.SetObserverInitContainerDefaults(o.Spec.DataGuard.Observer.PodTemplate, oraVersion)
 		o.SetOracleObserverContainerDefaults(o.Spec.DataGuard.Observer.PodTemplate, oraVersion)
+		apis.SetDefaultResizePolicy(o.Spec.DataGuard.Observer.PodTemplate.Spec.Containers, o.Spec.DataGuard.Observer.PodTemplate.Spec.InitContainers)
 	}
 
 	o.SetDefaultPodSecurityContext(o.Spec.PodTemplate, oraVersion)
 	o.SetOracleContainerDefaults(o.Spec.PodTemplate, oraVersion)
 	o.SetCoordinatorContainerDefaults(o.Spec.PodTemplate, oraVersion)
 	o.SetInitContainerDefaults(o.Spec.PodTemplate, oraVersion)
+	apis.SetDefaultResizePolicy(o.Spec.PodTemplate.Spec.Containers, o.Spec.PodTemplate.Spec.InitContainers)
 	o.SetHealthCheckerDefaults()
 	o.Spec.Monitor.SetDefaults()
 	o.SetTcpsDefaults()

--- a/apis/kubedb/v1alpha2/pgpool_helpers.go
+++ b/apis/kubedb/v1alpha2/pgpool_helpers.go
@@ -409,6 +409,7 @@ func (p *Pgpool) SetDefaults(client client.Client) {
 	p.SetHealthCheckerDefaults()
 	p.SetSecurityContext(&ppVersion, p.Spec.PodTemplate)
 	p.setContainerResourceLimits(p.Spec.PodTemplate)
+	apis.SetDefaultResizePolicy(p.Spec.PodTemplate.Spec.Containers, p.Spec.PodTemplate.Spec.InitContainers)
 }
 
 func (p *Pgpool) GetPersistentSecrets() []string {

--- a/apis/kubedb/v1alpha2/qdrant_helpers.go
+++ b/apis/kubedb/v1alpha2/qdrant_helpers.go
@@ -429,4 +429,6 @@ func (q *Qdrant) setDefaultContainerResourceLimits(podTemplate *ofst.PodTemplate
 	if dbContainer != nil {
 		apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResources)
 	}
+
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }

--- a/apis/kubedb/v1alpha2/rabbitmq_helpers.go
+++ b/apis/kubedb/v1alpha2/rabbitmq_helpers.go
@@ -375,6 +375,8 @@ func (r *RabbitMQ) setDefaultContainerSecurityContext(rmVersion *catalog.RabbitM
 		initContainer.SecurityContext = &core.SecurityContext{}
 	}
 	r.assignDefaultInitContainerSecurityContext(rmVersion, initContainer.SecurityContext)
+
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (r *RabbitMQ) assignDefaultInitContainerSecurityContext(rmVersion *catalog.RabbitMQVersion, rc *core.SecurityContext) {

--- a/apis/kubedb/v1alpha2/singlestore_helpers.go
+++ b/apis/kubedb/v1alpha2/singlestore_helpers.go
@@ -513,6 +513,8 @@ func (s *Singlestore) setDefaultContainerResourceLimits(podTemplate *ofst.PodTem
 			apis.SetDefaultResourceLimits(&coordinatorContainer.Resources, kubedb.CoordinatorDefaultResources)
 		}
 	}
+
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (s *Singlestore) SetTLSDefaults() {

--- a/apis/kubedb/v1alpha2/solr_helpers.go
+++ b/apis/kubedb/v1alpha2/solr_helpers.go
@@ -490,6 +490,8 @@ func (s *Solr) setDefaultContainerResourceLimits(podTemplate *ofst.PodTemplateSp
 	if initContainer != nil && (initContainer.Resources.Requests == nil && initContainer.Resources.Limits == nil) {
 		apis.SetDefaultResourceLimits(&initContainer.Resources, kubedb.DefaultInitContainerResource)
 	}
+
+	apis.SetDefaultResizePolicy(podTemplate.Spec.Containers, podTemplate.Spec.InitContainers)
 }
 
 func (s *Solr) SetHealthCheckerDefaults() {

--- a/apis/kubedb/v1alpha2/weaviate_helpers.go
+++ b/apis/kubedb/v1alpha2/weaviate_helpers.go
@@ -212,6 +212,8 @@ func (w *Weaviate) SetDefaults(kc client.Client) {
 		apis.SetDefaultResourceLimits(&dbContainer.Resources, kubedb.DefaultResources)
 	}
 
+	apis.SetDefaultResizePolicy(w.Spec.PodTemplate.Spec.Containers, w.Spec.PodTemplate.Spec.InitContainers)
+
 	w.SetHealthCheckerDefaults()
 	w.SetTLSDefaults()
 }

--- a/apis/kubedb/v1alpha2/zookeeper_helpers.go
+++ b/apis/kubedb/v1alpha2/zookeeper_helpers.go
@@ -236,6 +236,8 @@ func (z *ZooKeeper) SetDefaults(kc client.Client) {
 		apis.SetDefaultResourceLimits(&initContainer.Resources, kubedb.DefaultInitContainerResource)
 	}
 
+	apis.SetDefaultResizePolicy(z.Spec.PodTemplate.Spec.Containers, z.Spec.PodTemplate.Spec.InitContainers)
+
 	if z.Spec.EnableSSL {
 		z.SetTLSDefaults()
 	}


### PR DESCRIPTION
## What

Adds a db-agnostic default in-place `resizePolicy` (cpu & memory → `NotRequired`) for every database container and initContainer, applied during `SetDefaults`.

```yaml
resizePolicy:
- {resourceName: cpu,    restartPolicy: NotRequired}
- {resourceName: memory, restartPolicy: NotRequired}
```

## How

New shared helper in `apis/helpers.go`:

```go
func SetDefaultResizePolicy(containers ...[]core.Container)
```

It sets the policy on any container whose `ResizePolicy` is unset (existing values are preserved). Each database calls `apis.SetDefaultResizePolicy(pt.Spec.Containers, pt.Spec.InitContainers)` after its pod template's containers are finalized — covering standalone, topology, arbiter/hidden/coordinator/observer pod templates as applicable.

## Coverage

- **`v1`** — all 12 databases
- **`v1alpha2`** — all 21 offshoot-api **v2** databases

**Excluded:** the 11 legacy `v1alpha2` databases on offshoot-api **v1** (elasticsearch, mariadb, memcached, mongodb, mysql, perconaxtradb, pgbouncer, postgres, proxysql, redis, redis_sentinel). Their `PodSpec` has no `Containers`/`ResizePolicy` field, so a per-container resize policy cannot be expressed there; their `v1` counterparts (offshoot-v2) carry it.

## Verification

- `go build ./...` passes.