### PR TITLE
Add InPlace mode and MemoryPolicy to PostgresOpsRequest vertical scaling

### DIFF
--- a/apis/ops/v1alpha1/constant.go
+++ b/apis/ops/v1alpha1/constant.go
@@ -73,6 +73,13 @@ const (
 	VerticalScaleFailed    = "VerticalScaleFailed"
 )
 
+// In-place Vertical Scaling
+const (
+	InPlaceResizeEligible   = "InPlaceResizeEligible"
+	InPlaceResizeDeferred   = "InPlaceResizeDeferred"
+	InPlaceResizeInfeasible = "InPlaceResizeInfeasible"
+)
+
 // Volume Expansion
 const (
 	VolumeExpansion          = "VolumeExpansion"

--- a/apis/ops/v1alpha1/openapi_generated.go
+++ b/apis/ops/v1alpha1/openapi_generated.go
@@ -43131,6 +43131,21 @@ func schema_apimachinery_apis_ops_v1alpha1_PostgresVerticalScalingSpec(ref commo
 							},
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Default:     "Restart",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"memoryPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MemoryPolicy controls how a memory change is handled when Mode=InPlace. Defaults to ResizeOnly when Mode=InPlace.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/apis/ops/v1alpha1/postgres_ops_types.go
+++ b/apis/ops/v1alpha1/postgres_ops_types.go
@@ -196,6 +196,14 @@ type PostgresVerticalScalingSpec struct {
 	Coordinator  *ContainerResources    `json:"coordinator,omitempty"`
 	Arbiter      *PodResources          `json:"arbiter,omitempty"`
 	ReadReplicas []ReadReplicaResources `json:"readReplicas,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
+	// MemoryPolicy controls how a memory change is handled when Mode=InPlace.
+	// Defaults to ResizeOnly when Mode=InPlace.
+	// +optional
+	MemoryPolicy MemoryResizePolicy `json:"memoryPolicy,omitempty"`
 }
 
 type ReadReplicaResources struct {

--- a/apis/ops/v1alpha1/type.go
+++ b/apis/ops/v1alpha1/type.go
@@ -114,6 +114,30 @@ const (
 	VolumeExpansionModeOffline VolumeExpansionMode = "Offline"
 )
 
+// +kubebuilder:validation:Enum=Restart;InPlace
+type VerticalScalingMode string
+
+const (
+	// VerticalScalingModeRestart actuates a vertical scaling by patching the
+	// pod template and restarting the pods (the default, restart-based path).
+	VerticalScalingModeRestart VerticalScalingMode = "Restart"
+	// VerticalScalingModeInPlace actuates a vertical scaling in place via the
+	// pods/resize subresource, falling back to restart when infeasible.
+	VerticalScalingModeInPlace VerticalScalingMode = "InPlace"
+)
+
+// +kubebuilder:validation:Enum=ResizeOnly;Retune
+type MemoryResizePolicy string
+
+const (
+	// MemoryResizePolicyResizeOnly grows the cgroup limit only, keeping
+	// shared_buffers unchanged, so no container restart is required.
+	MemoryResizePolicyResizeOnly MemoryResizePolicy = "ResizeOnly"
+	// MemoryResizePolicyRetune retunes shared_buffers, which requires a
+	// container restart and therefore uses the restart path.
+	MemoryResizePolicyRetune MemoryResizePolicy = "Retune"
+)
+
 type RestartSpec struct{}
 
 type Reprovision struct{}

--- a/crds/ops.kubedb.com_postgresopsrequests.yaml
+++ b/crds/ops.kubedb.com_postgresopsrequests.yaml
@@ -664,6 +664,17 @@ spec:
                             type: object
                         type: object
                     type: object
+                  memoryPolicy:
+                    enum:
+                    - ResizeOnly
+                    - Retune
+                    type: string
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   postgres:
                     properties:
                       nodeSelectionPolicy:

--- a/pkg/webhooks/ops/v1alpha1/postgres.go
+++ b/pkg/webhooks/ops/v1alpha1/postgres.go
@@ -50,6 +50,7 @@ import (
 func SetupPostgresOpsRequestWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).For(&opsapi.PostgresOpsRequest{}).
 		WithValidator(&PostgresOpsRequestCustomWebhook{mgr.GetClient()}).
+		WithDefaulter(&PostgresOpsRequestCustomWebhook{mgr.GetClient()}).
 		Complete()
 }
 
@@ -59,6 +60,27 @@ type PostgresOpsRequestCustomWebhook struct {
 
 // log is for logging in this package.
 var postgresLog = logf.Log.WithName("postgres-opsrequest")
+
+var _ webhook.CustomDefaulter = &PostgresOpsRequestCustomWebhook{}
+
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type
+func (w *PostgresOpsRequestCustomWebhook) Default(_ context.Context, obj runtime.Object) error {
+	ops, ok := obj.(*opsapi.PostgresOpsRequest)
+	if !ok {
+		return fmt.Errorf("expected an PostgresOpsRequest object but got %T", obj)
+	}
+	postgresLog.Info("defaulting", "name", ops.Name)
+
+	// When an in-place vertical scaling is requested without an explicit memory
+	// policy, default it to ResizeOnly (grow cgroup, keep shared_buffers). InPlace
+	// is never hard-rejected here; ineligible requests fall back at runtime.
+	if ops.Spec.VerticalScaling != nil &&
+		ops.Spec.VerticalScaling.Mode == opsapi.VerticalScalingModeInPlace &&
+		ops.Spec.VerticalScaling.MemoryPolicy == "" {
+		ops.Spec.VerticalScaling.MemoryPolicy = opsapi.MemoryResizePolicyResizeOnly
+	}
+	return nil
+}
 
 var _ webhook.CustomValidator = &PostgresOpsRequestCustomWebhook{}
 


### PR DESCRIPTION
## What

API surface for in-place (no-restart) Postgres vertical scaling.

- `apis/ops/v1alpha1/type.go`: `VerticalScalingMode` enum (`Restart` | `InPlace`) and `MemoryResizePolicy` enum (`ResizeOnly` | `Retune`), mirroring the `VolumeExpansionMode` pattern.
- `PostgresVerticalScalingSpec`: `Mode` (`+kubebuilder:default=Restart`) and `MemoryPolicy` fields.
- Condition constants `InPlaceResizeEligible`, `InPlaceResizeDeferred`, `InPlaceResizeInfeasible`.
- A `PostgresOpsRequest` webhook defaulter that sets `MemoryPolicy=ResizeOnly` when `Mode=InPlace` and unset.
- Regenerated CRD + OpenAPI for the new fields (hand-spliced — the Docker `make gen` rewrites/strips unrelated generated files when run alone; deepcopy needs no change since the fields are scalar strings).

`Mode` defaults to `Restart`, so existing OpsRequests and behavior are unchanged.

## Notes

- The defaulter only fires once the installer adds a `MutatingWebhookConfiguration` for `postgresopsrequests` (ops requests historically have only a validating webhook). Correctness does not depend on it: the operator treats an empty `MemoryPolicy` as `ResizeOnly`, and `Mode`'s CRD-level default is applied by the apiserver regardless.

## Part of a coordinated set

Foundation PR. Dependents: kubedb/postgres#911 and kubedb/autoscaler#310 (they bump apimachinery to this commit); actuation by kubeops/petset#50. Release apimachinery and petset first.