### PR TITLE
Add ReconfigureTLS ops type and TLS spec to OracleOpsRequest

### DIFF
--- a/apis/ops/v1alpha1/openapi_generated.go
+++ b/apis/ops/v1alpha1/openapi_generated.go
@@ -41238,6 +41238,12 @@ func schema_apimachinery_apis_ops_v1alpha1_OracleOpsRequestSpec(ref common.Refer
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.OracleMigrationSpec"),
 						},
 					},
+					"tls": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specifies information necessary for TLS reconfiguration",
+							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.TLSSpec"),
+						},
+					},
 					"timeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Timeout for each step of the ops request in second. If a step doesn't finish within the specified timeout, the ops request will result in failure.",
@@ -41256,7 +41262,7 @@ func schema_apimachinery_apis_ops_v1alpha1_OracleOpsRequestSpec(ref common.Refer
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration", "kubedb.dev/apimachinery/apis/ops/v1alpha1.AuthSpec", "kubedb.dev/apimachinery/apis/ops/v1alpha1.OracleMigrationSpec", "kubedb.dev/apimachinery/apis/ops/v1alpha1.OracleReconfigurationSpec", "kubedb.dev/apimachinery/apis/ops/v1alpha1.OracleVerticalScalingSpec", "kubedb.dev/apimachinery/apis/ops/v1alpha1.OracleVolumeExpansionSpec", "kubedb.dev/apimachinery/apis/ops/v1alpha1.RestartSpec"},
+			"k8s.io/api/core/v1.LocalObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration", "kubedb.dev/apimachinery/apis/ops/v1alpha1.AuthSpec", "kubedb.dev/apimachinery/apis/ops/v1alpha1.OracleMigrationSpec", "kubedb.dev/apimachinery/apis/ops/v1alpha1.OracleReconfigurationSpec", "kubedb.dev/apimachinery/apis/ops/v1alpha1.OracleVerticalScalingSpec", "kubedb.dev/apimachinery/apis/ops/v1alpha1.OracleVolumeExpansionSpec", "kubedb.dev/apimachinery/apis/ops/v1alpha1.RestartSpec", "kubedb.dev/apimachinery/apis/ops/v1alpha1.TLSSpec"},
 	}
 }
 

--- a/apis/ops/v1alpha1/oracle_ops_types.go
+++ b/apis/ops/v1alpha1/oracle_ops_types.go
@@ -68,6 +68,9 @@ type OracleOpsRequestSpec struct {
 	Restart *RestartSpec `json:"restart,omitempty"`
 	// Specifies information necessary for migrating storage
 	Migration *OracleMigrationSpec `json:"migration,omitempty"`
+	// Specifies information necessary for TLS reconfiguration
+	// +optional
+	TLS *TLSSpec `json:"tls,omitempty"`
 	// Timeout for each step of the ops request in second. If a step doesn't finish within the specified timeout, the ops request will result in failure.
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 	// ApplyOption is to control the execution of OpsRequest depending on the database state.
@@ -88,8 +91,8 @@ type OracleMigrationSpec struct {
 	OldPVReclaimPolicy core.PersistentVolumeReclaimPolicy `json:"oldPVReclaimPolicy,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=Restart;Reconfigure;StorageMigration;VerticalScaling;VolumeExpansion;RotateAuth
-// ENUM(Restart, Reconfigure, StorageMigration, VerticalScaling, VolumeExpansion, RotateAuth)
+// +kubebuilder:validation:Enum=Restart;Reconfigure;ReconfigureTLS;StorageMigration;VerticalScaling;VolumeExpansion;RotateAuth
+// ENUM(Restart, Reconfigure, ReconfigureTLS, StorageMigration, VerticalScaling, VolumeExpansion, RotateAuth)
 type OracleOpsRequestType string
 
 // OracleVerticalScalingSpec contains the vertical scaling information of an Oracle cluster

--- a/apis/ops/v1alpha1/oracle_ops_types_enum.go
+++ b/apis/ops/v1alpha1/oracle_ops_types_enum.go
@@ -15,6 +15,8 @@ const (
 	OracleOpsRequestTypeRestart OracleOpsRequestType = "Restart"
 	// OracleOpsRequestTypeReconfigure is a OracleOpsRequestType of type Reconfigure.
 	OracleOpsRequestTypeReconfigure OracleOpsRequestType = "Reconfigure"
+	// OracleOpsRequestTypeReconfigureTLS is a OracleOpsRequestType of type ReconfigureTLS.
+	OracleOpsRequestTypeReconfigureTLS OracleOpsRequestType = "ReconfigureTLS"
 	// OracleOpsRequestTypeStorageMigration is a OracleOpsRequestType of type StorageMigration.
 	OracleOpsRequestTypeStorageMigration OracleOpsRequestType = "StorageMigration"
 	// OracleOpsRequestTypeVerticalScaling is a OracleOpsRequestType of type VerticalScaling.
@@ -30,6 +32,7 @@ var ErrInvalidOracleOpsRequestType = fmt.Errorf("not a valid OracleOpsRequestTyp
 var _OracleOpsRequestTypeNames = []string{
 	string(OracleOpsRequestTypeRestart),
 	string(OracleOpsRequestTypeReconfigure),
+	string(OracleOpsRequestTypeReconfigureTLS),
 	string(OracleOpsRequestTypeStorageMigration),
 	string(OracleOpsRequestTypeVerticalScaling),
 	string(OracleOpsRequestTypeVolumeExpansion),
@@ -48,6 +51,7 @@ func OracleOpsRequestTypeValues() []OracleOpsRequestType {
 	return []OracleOpsRequestType{
 		OracleOpsRequestTypeRestart,
 		OracleOpsRequestTypeReconfigure,
+		OracleOpsRequestTypeReconfigureTLS,
 		OracleOpsRequestTypeStorageMigration,
 		OracleOpsRequestTypeVerticalScaling,
 		OracleOpsRequestTypeVolumeExpansion,
@@ -70,6 +74,7 @@ func (x OracleOpsRequestType) IsValid() bool {
 var _OracleOpsRequestTypeValue = map[string]OracleOpsRequestType{
 	"Restart":          OracleOpsRequestTypeRestart,
 	"Reconfigure":      OracleOpsRequestTypeReconfigure,
+	"ReconfigureTLS":   OracleOpsRequestTypeReconfigureTLS,
 	"StorageMigration": OracleOpsRequestTypeStorageMigration,
 	"VerticalScaling":  OracleOpsRequestTypeVerticalScaling,
 	"VolumeExpansion":  OracleOpsRequestTypeVolumeExpansion,

--- a/apis/ops/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/ops/v1alpha1/zz_generated.deepcopy.go
@@ -5485,6 +5485,11 @@ func (in *OracleOpsRequestSpec) DeepCopyInto(out *OracleOpsRequestSpec) {
 		*out = new(OracleMigrationSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.TLS != nil {
+		in, out := &in.TLS, &out.TLS
+		*out = new(TLSSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(v1.Duration)

--- a/crds/ops.kubedb.com_oracleopsrequests.yaml
+++ b/crds/ops.kubedb.com_oracleopsrequests.yaml
@@ -116,10 +116,116 @@ spec:
                 type: object
               timeout:
                 type: string
+              tls:
+                properties:
+                  certificates:
+                    items:
+                      properties:
+                        alias:
+                          type: string
+                        dnsNames:
+                          items:
+                            type: string
+                          type: array
+                        duration:
+                          type: string
+                        emailAddresses:
+                          items:
+                            type: string
+                          type: array
+                        ipAddresses:
+                          items:
+                            type: string
+                          type: array
+                        issuerRef:
+                          properties:
+                            apiGroup:
+                              type: string
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        privateKey:
+                          properties:
+                            encoding:
+                              enum:
+                              - PKCS1
+                              - PKCS8
+                              type: string
+                          type: object
+                        renewBefore:
+                          type: string
+                        secretName:
+                          type: string
+                        subject:
+                          properties:
+                            countries:
+                              items:
+                                type: string
+                              type: array
+                            localities:
+                              items:
+                                type: string
+                              type: array
+                            organizationalUnits:
+                              items:
+                                type: string
+                              type: array
+                            organizations:
+                              items:
+                                type: string
+                              type: array
+                            postalCodes:
+                              items:
+                                type: string
+                              type: array
+                            provinces:
+                              items:
+                                type: string
+                              type: array
+                            serialNumber:
+                              type: string
+                            streetAddresses:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        uris:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - alias
+                      type: object
+                    type: array
+                  issuerRef:
+                    properties:
+                      apiGroup:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  remove:
+                    type: boolean
+                  rotateCertificates:
+                    type: boolean
+                type: object
               type:
                 enum:
                 - Restart
                 - Reconfigure
+                - ReconfigureTLS
                 - StorageMigration
                 - VerticalScaling
                 - VolumeExpansion

--- a/pkg/webhooks/ops/v1alpha1/oracle.go
+++ b/pkg/webhooks/ops/v1alpha1/oracle.go
@@ -135,6 +135,12 @@ func (w *OracleOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.Oracl
 				req.Name,
 				err.Error()))
 		}
+	case opsapi.OracleOpsRequestTypeReconfigureTLS:
+		if err := w.validateOracleReconfigureTLSOpsRequest(req); err != nil {
+			allErr = append(allErr, field.Invalid(field.NewPath("spec").Child("tls"),
+				req.Name,
+				err.Error()))
+		}
 	case opsapi.OracleOpsRequestTypeStorageMigration:
 		if err := w.validateOracleStorageMigrationOpsRequest(req); err != nil {
 			allErr = append(allErr, field.Invalid(field.NewPath("spec").Child("migration"),
@@ -162,11 +168,21 @@ func (w *OracleOpsRequestCustomWebhook) hasDatabaseRef(req *opsapi.OracleOpsRequ
 	return oracle, nil
 }
 
+func (w *OracleOpsRequestCustomWebhook) validateOracleReconfigureTLSOpsRequest(req *opsapi.OracleOpsRequest) error {
+	tls := req.Spec.TLS
+	if tls == nil {
+		return errors.New("`spec.tls` nil not supported in ReconfigureTLS type")
+	}
+
+	return nil
+}
+
+
 func (w *OracleOpsRequestCustomWebhook) validateOracleStorageMigrationOpsRequest(req *opsapi.OracleOpsRequest) error {
 	db := &dbapi.Oracle{}
 	err := w.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: req.GetDBRefName(), Namespace: req.GetNamespace()}, db)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to get postgres: %s/%s", req.Namespace, req.Spec.DatabaseRef.Name))
+		return errors.Wrap(err, fmt.Sprintf("failed to get oracle: %s/%s", req.Namespace, req.Spec.DatabaseRef.Name))
 	}
 
 	if req.Spec.Migration.StorageClassName == nil {

--- a/pkg/webhooks/ops/v1alpha1/oracle.go
+++ b/pkg/webhooks/ops/v1alpha1/oracle.go
@@ -177,7 +177,6 @@ func (w *OracleOpsRequestCustomWebhook) validateOracleReconfigureTLSOpsRequest(r
 	return nil
 }
 
-
 func (w *OracleOpsRequestCustomWebhook) validateOracleStorageMigrationOpsRequest(req *opsapi.OracleOpsRequest) error {
 	db := &dbapi.Oracle{}
 	err := w.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: req.GetDBRefName(), Namespace: req.GetNamespace()}, db)


### PR DESCRIPTION
## Summary

Adds the API surface for **Reconfigure TLS** on Oracle via `OracleOpsRequest`:

- Adds `ReconfigureTLS` to the `OracleOpsRequestType` enum.
- Adds a `TLS *TLSSpec` field to `OracleOpsRequestSpec` (reusing the shared `TLSSpec` type already used by Postgres/MySQL/etc. ops requests — `Certificates`, `IssuerRef`, `RotateCertificates`, `Remove`).
- Regenerated the enum stringer, deepcopy, openapi and CRD for the new field.

This is the shared apimachinery change that the Oracle operator's `ReconfigureTLS()` implementation depends on.

## Note on generated code

`make gen` in this environment (Docker-based) gutted unrelated generated files (clientset, cross-group openapi, api-rule violation list). Only the artifacts genuinely affected by this change are included: the go-enum stringer and CRD were produced cleanly by the generators; the deepcopy and ops-group openapi entries for the new `TLS` field were hand-spliced to match the generated shape. No unrelated files are touched.