### PR TITLE
Add VerticalScalingMode to all vertical scaling specs

### DIFF
--- a/apis/ops/v1alpha1/aerospike_ops_types.go
+++ b/apis/ops/v1alpha1/aerospike_ops_types.go
@@ -64,6 +64,10 @@ type AerospikeOpsRequestSpec struct {
 type AerospikeVerticalScalingSpec struct {
 	Aerospike *PodResources       `json:"aerospike,omitempty"`
 	Exporter  *ContainerResources `json:"exporter,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=VerticalScaling;Restart

--- a/apis/ops/v1alpha1/cassandra_ops-types.go
+++ b/apis/ops/v1alpha1/cassandra_ops-types.go
@@ -107,6 +107,10 @@ type CassandraUpdateVersionSpec struct {
 type CassandraVerticalScalingSpec struct {
 	// Resource spec for nodes
 	Node *PodResources `json:"node,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // CassandraVolumeExpansionSpec is the spec for Cassandra volume expansion

--- a/apis/ops/v1alpha1/clickhouse_ops-types.go
+++ b/apis/ops/v1alpha1/clickhouse_ops-types.go
@@ -112,6 +112,10 @@ type ClickHouseTLSSpec struct {
 // ClickHouseVerticalScalingSpec contains the vertical scaling information of a clickhouse cluster
 type ClickHouseVerticalScalingSpec struct {
 	Node *PodResources `json:"node,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // ClickHouseHorizontalScalingSpec contains the horizontal scaling information of a clickhouse cluster

--- a/apis/ops/v1alpha1/db2_ops_types.go
+++ b/apis/ops/v1alpha1/db2_ops_types.go
@@ -64,6 +64,10 @@ type DB2OpsRequestSpec struct {
 type DB2VerticalScalingSpec struct {
 	DB2      *PodResources       `json:"db2,omitempty"`
 	Exporter *ContainerResources `json:"exporter,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=VerticalScaling;Restart

--- a/apis/ops/v1alpha1/documentdb_ops_types.go
+++ b/apis/ops/v1alpha1/documentdb_ops_types.go
@@ -172,6 +172,10 @@ type DocumentDBVerticalScalingSpec struct {
 	Coordinator  *ContainerResources              `json:"coordinator,omitempty"`
 	Arbiter      *PodResources                    `json:"arbiter,omitempty"`
 	ReadReplicas []DocumentDBReadReplicaResources `json:"readReplicas,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 type DocumentDBReadReplicaResources struct {

--- a/apis/ops/v1alpha1/druid_ops_types.go
+++ b/apis/ops/v1alpha1/druid_ops_types.go
@@ -94,6 +94,10 @@ type DruidVerticalScalingSpec struct {
 	Historicals    *PodResources `json:"historicals,omitempty"`
 	Brokers        *PodResources `json:"brokers,omitempty"`
 	Routers        *PodResources `json:"routers,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // DruidHorizontalScalingSpec contains the horizontal scaling information of a Druid cluster

--- a/apis/ops/v1alpha1/elasticsearch_ops_types.go
+++ b/apis/ops/v1alpha1/elasticsearch_ops_types.go
@@ -137,6 +137,10 @@ type ElasticsearchVerticalScalingSpec struct {
 	ML           *PodResources       `json:"ml,omitempty"`
 	Transform    *PodResources       `json:"transform,omitempty"`
 	Coordinating *PodResources       `json:"coordinating,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // ElasticsearchVolumeExpansionSpec is the spec for Elasticsearch volume expansion

--- a/apis/ops/v1alpha1/hanadb_ops_types.go
+++ b/apis/ops/v1alpha1/hanadb_ops_types.go
@@ -79,6 +79,10 @@ type HanaDBVerticalScalingSpec struct {
 	HanaDB      *PodResources       `json:"hanadb,omitempty"`
 	Coordinator *ContainerResources `json:"coordinator,omitempty"`
 	Exporter    *ContainerResources `json:"exporter,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // HanaDBVolumeExpansionSpec is the spec for HanaDB volume expansion.

--- a/apis/ops/v1alpha1/hazelcast_ops_types.go
+++ b/apis/ops/v1alpha1/hazelcast_ops_types.go
@@ -89,6 +89,10 @@ type HazelcastOpsRequestSpec struct {
 type HazelcastVerticalScalingSpec struct {
 	// Resource spec for hazelcast nodes
 	Hazelcast *PodResources `json:"hazelcast,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 type HazelcastVolumeExpansionSpec struct {

--- a/apis/ops/v1alpha1/ignite_ops_types.go
+++ b/apis/ops/v1alpha1/ignite_ops_types.go
@@ -102,6 +102,10 @@ type IgniteHorizontalScalingSpec struct {
 type IgniteVerticalScalingSpec struct {
 	// Resource spec for nodes
 	Ignite *PodResources `json:"node,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // IgniteVolumeExpansionSpec is the spec for Ignite volume expansion

--- a/apis/ops/v1alpha1/kafka_ops_types.go
+++ b/apis/ops/v1alpha1/kafka_ops_types.go
@@ -134,6 +134,10 @@ type KafkaVerticalScalingSpec struct {
 	Broker *PodResources `json:"broker,omitempty"`
 	// Resource spec for controller
 	Controller *PodResources `json:"controller,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // KafkaVolumeExpansionSpec is the spec for Kafka volume expansion

--- a/apis/ops/v1alpha1/mariadb_ops_types.go
+++ b/apis/ops/v1alpha1/mariadb_ops_types.go
@@ -125,6 +125,10 @@ type MariaDBVerticalScalingSpec struct {
 	MaxScale    *PodResources       `json:"maxscale,omitempty"`
 	Exporter    *ContainerResources `json:"exporter,omitempty"`
 	Coordinator *ContainerResources `json:"coordinator,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // MariaDBVolumeExpansionSpec is the spec for MariaDB volume expansion

--- a/apis/ops/v1alpha1/memcached_ops_types.go
+++ b/apis/ops/v1alpha1/memcached_ops_types.go
@@ -104,6 +104,10 @@ type MemcachedVerticalScalingSpec struct {
 	Memcached         *PodResources                      `json:"memcached,omitempty"`
 	Exporter          *ContainerResources                `json:"exporter,omitempty"`
 	ReadinessCriteria *MemcachedReplicaReadinessCriteria `json:"readinessCriteria,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // MemcachedVolumeExpansionSpec is the spec for Memcached volume expansion

--- a/apis/ops/v1alpha1/milvus_ops_types.go
+++ b/apis/ops/v1alpha1/milvus_ops_types.go
@@ -128,6 +128,10 @@ type MilvusVerticalScalingSpec struct {
 	DataNode      *PodResources `json:"datanode,omitempty"`
 	QueryNode     *PodResources `json:"querynode,omitempty"`
 	StreamingNode *PodResources `json:"streamingnode,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // MilvusVolumeExpansionSpec is the spec for Milvus volume expansion

--- a/apis/ops/v1alpha1/mongodb_ops_types.go
+++ b/apis/ops/v1alpha1/mongodb_ops_types.go
@@ -171,6 +171,10 @@ type MongoDBVerticalScalingSpec struct {
 	Hidden       *PodResources       `json:"hidden,omitempty"`
 	Exporter     *ContainerResources `json:"exporter,omitempty"`
 	Coordinator  *ContainerResources `json:"coordinator,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // MongoDBVolumeExpansionSpec is the spec for mongodb volume expansion

--- a/apis/ops/v1alpha1/mssqlserver_ops_types.go
+++ b/apis/ops/v1alpha1/mssqlserver_ops_types.go
@@ -110,6 +110,10 @@ type MSSQLServerVerticalScalingSpec struct {
 	Exporter    *ContainerResources `json:"exporter,omitempty"`
 	Coordinator *ContainerResources `json:"coordinator,omitempty"`
 	Arbiter     *PodResources       `json:"arbiter,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // MSSQLServerVolumeExpansionSpec is the spec for MSSQLServer volume expansion

--- a/apis/ops/v1alpha1/mysql_ops_types.go
+++ b/apis/ops/v1alpha1/mysql_ops_types.go
@@ -124,6 +124,10 @@ type MySQLVerticalScalingSpec struct {
 	MySQL       *PodResources       `json:"mysql,omitempty"`
 	Exporter    *ContainerResources `json:"exporter,omitempty"`
 	Coordinator *ContainerResources `json:"coordinator,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // MySQLVolumeExpansionSpec is the spec for MySQL volume expansion

--- a/apis/ops/v1alpha1/neo4j_ops_types.go
+++ b/apis/ops/v1alpha1/neo4j_ops_types.go
@@ -133,6 +133,10 @@ type Neo4jHorizontalScalingSpec struct {
 type Neo4jVerticalScalingSpec struct {
 	// Resource spec for neo4j servers
 	Server *PodResources `json:"server,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 type Neo4jTLSSpec struct {

--- a/apis/ops/v1alpha1/openapi_generated.go
+++ b/apis/ops/v1alpha1/openapi_generated.go
@@ -33772,6 +33772,13 @@ func schema_apimachinery_apis_ops_v1alpha1_AerospikeVerticalScalingSpec(ref comm
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.ContainerResources"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -34164,6 +34171,13 @@ func schema_apimachinery_apis_ops_v1alpha1_CassandraVerticalScalingSpec(ref comm
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -34541,6 +34555,13 @@ func schema_apimachinery_apis_ops_v1alpha1_ClickHouseVerticalScalingSpec(ref com
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -34785,6 +34806,13 @@ func schema_apimachinery_apis_ops_v1alpha1_DB2VerticalScalingSpec(ref common.Ref
 					"exporter": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.ContainerResources"),
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -35531,6 +35559,13 @@ func schema_apimachinery_apis_ops_v1alpha1_DocumentDBVerticalScalingSpec(ref com
 							},
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -35903,6 +35938,13 @@ func schema_apimachinery_apis_ops_v1alpha1_DruidVerticalScalingSpec(ref common.R
 					"routers": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -36552,6 +36594,13 @@ func schema_apimachinery_apis_ops_v1alpha1_ElasticsearchVerticalScalingSpec(ref 
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -36897,6 +36946,13 @@ func schema_apimachinery_apis_ops_v1alpha1_HanaDBVerticalScalingSpec(ref common.
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.ContainerResources"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -37180,6 +37236,13 @@ func schema_apimachinery_apis_ops_v1alpha1_HazelcastVerticalScalingSpec(ref comm
 						SchemaProps: spec.SchemaProps{
 							Description: "Resource spec for hazelcast nodes",
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -37521,6 +37584,13 @@ func schema_apimachinery_apis_ops_v1alpha1_IgniteVerticalScalingSpec(ref common.
 						SchemaProps: spec.SchemaProps{
 							Description: "Resource spec for nodes",
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -37903,6 +37973,13 @@ func schema_apimachinery_apis_ops_v1alpha1_KafkaVerticalScalingSpec(ref common.R
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -38281,6 +38358,13 @@ func schema_apimachinery_apis_ops_v1alpha1_MSSQLServerVerticalScalingSpec(ref co
 					"arbiter": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -38739,6 +38823,13 @@ func schema_apimachinery_apis_ops_v1alpha1_MariaDBVerticalScalingSpec(ref common
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.ContainerResources"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -39130,6 +39221,13 @@ func schema_apimachinery_apis_ops_v1alpha1_MemcachedVerticalScalingSpec(ref comm
 					"readinessCriteria": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.MemcachedReplicaReadinessCriteria"),
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -39547,6 +39645,13 @@ func schema_apimachinery_apis_ops_v1alpha1_MilvusVerticalScalingSpec(ref common.
 					"streamingnode": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -40069,6 +40174,13 @@ func schema_apimachinery_apis_ops_v1alpha1_MongoDBVerticalScalingSpec(ref common
 					"coordinator": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.ContainerResources"),
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -40601,6 +40713,13 @@ func schema_apimachinery_apis_ops_v1alpha1_MySQLVerticalScalingSpec(ref common.R
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.ContainerResources"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -40965,6 +41084,13 @@ func schema_apimachinery_apis_ops_v1alpha1_Neo4jVerticalScalingSpec(ref common.R
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -41327,6 +41453,13 @@ func schema_apimachinery_apis_ops_v1alpha1_OracleVerticalScalingSpec(ref common.
 						SchemaProps: spec.SchemaProps{
 							Description: "Resource spec for nodes",
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -41747,6 +41880,13 @@ func schema_apimachinery_apis_ops_v1alpha1_PerconaXtraDBVerticalScalingSpec(ref 
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.ContainerResources"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -42085,6 +42225,13 @@ func schema_apimachinery_apis_ops_v1alpha1_PgBouncerVerticalScalingSpec(ref comm
 					"exporter": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.ContainerResources"),
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -42493,6 +42640,13 @@ func schema_apimachinery_apis_ops_v1alpha1_PgpoolVerticalScalingSpec(ref common.
 						SchemaProps: spec.SchemaProps{
 							Description: "Resource spec for nodes",
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -43131,6 +43285,13 @@ func schema_apimachinery_apis_ops_v1alpha1_PostgresVerticalScalingSpec(ref commo
 							},
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -43503,6 +43664,13 @@ func schema_apimachinery_apis_ops_v1alpha1_ProxySQLVerticalScalingSpec(ref commo
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -43834,6 +44002,13 @@ func schema_apimachinery_apis_ops_v1alpha1_QdrantVerticalScalingSpec(ref common.
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -44132,6 +44307,13 @@ func schema_apimachinery_apis_ops_v1alpha1_RabbitMQVerticalScalingSpec(ref commo
 						SchemaProps: spec.SchemaProps{
 							Description: "Resource spec for nodes",
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -45091,6 +45273,13 @@ func schema_apimachinery_apis_ops_v1alpha1_RedisSentinelVerticalScalingSpec(ref 
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.ContainerResources"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -45227,6 +45416,13 @@ func schema_apimachinery_apis_ops_v1alpha1_RedisVerticalScalingSpec(ref common.R
 					"coordinator": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.ContainerResources"),
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -45695,6 +45891,13 @@ func schema_apimachinery_apis_ops_v1alpha1_SinglestoreVerticalScalingSpec(ref co
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.ContainerResources"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -46069,6 +46272,13 @@ func schema_apimachinery_apis_ops_v1alpha1_SolrVerticalScalingSpec(ref common.Re
 						SchemaProps: spec.SchemaProps{
 							Description: "Resource spec for overseer nodes",
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -46599,6 +46809,13 @@ func schema_apimachinery_apis_ops_v1alpha1_WeaviateVerticalScalingSpec(ref commo
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -46891,6 +47108,13 @@ func schema_apimachinery_apis_ops_v1alpha1_ZooKeeperVerticalScalingSpec(ref comm
 						SchemaProps: spec.SchemaProps{
 							Description: "Resource spec for nodes",
 							Ref:         ref("kubedb.dev/apimachinery/apis/ops/v1alpha1.PodResources"),
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/apis/ops/v1alpha1/oracle_ops_types.go
+++ b/apis/ops/v1alpha1/oracle_ops_types.go
@@ -96,6 +96,10 @@ type OracleOpsRequestType string
 type OracleVerticalScalingSpec struct {
 	// Resource spec for nodes
 	Node *PodResources `json:"node,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // OracleVolumeExpansionSpec is the spec for Oracle volume expansion

--- a/apis/ops/v1alpha1/perconaxtradb_ops_types.go
+++ b/apis/ops/v1alpha1/perconaxtradb_ops_types.go
@@ -105,6 +105,10 @@ type PerconaXtraDBVerticalScalingSpec struct {
 	PerconaXtraDB *PodResources       `json:"perconaxtradb,omitempty"`
 	Exporter      *ContainerResources `json:"exporter,omitempty"`
 	Coordinator   *ContainerResources `json:"coordinator,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // PerconaXtraDBVolumeExpansionSpec is the spec for PerconaXtraDB volume expansion

--- a/apis/ops/v1alpha1/pgbouncer_ops_types.go
+++ b/apis/ops/v1alpha1/pgbouncer_ops_types.go
@@ -97,6 +97,10 @@ type PgBouncerHorizontalScalingSpec struct {
 type PgBouncerVerticalScalingSpec struct {
 	PgBouncer *PodResources       `json:"pgbouncer,omitempty"`
 	Exporter  *ContainerResources `json:"exporter,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 type PgBouncerTLSSpec struct {

--- a/apis/ops/v1alpha1/pgpool_ops_types.go
+++ b/apis/ops/v1alpha1/pgpool_ops_types.go
@@ -124,6 +124,10 @@ type PgpoolCustomConfigurationSpec struct {
 type PgpoolVerticalScalingSpec struct {
 	// Resource spec for nodes
 	Node *PodResources `json:"node,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/apis/ops/v1alpha1/postgres_ops_types.go
+++ b/apis/ops/v1alpha1/postgres_ops_types.go
@@ -196,6 +196,10 @@ type PostgresVerticalScalingSpec struct {
 	Coordinator  *ContainerResources    `json:"coordinator,omitempty"`
 	Arbiter      *PodResources          `json:"arbiter,omitempty"`
 	ReadReplicas []ReadReplicaResources `json:"readReplicas,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 type ReadReplicaResources struct {

--- a/apis/ops/v1alpha1/proxysql_ops_types.go
+++ b/apis/ops/v1alpha1/proxysql_ops_types.go
@@ -103,6 +103,10 @@ type ProxySQLHorizontalScalingSpec struct {
 // ProxySQLVerticalScalingSpec is the spec for ProxySQL vertical scaling
 type ProxySQLVerticalScalingSpec struct {
 	ProxySQL *PodResources `json:"proxysql,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 type ProxySQLCustomConfiguration struct {

--- a/apis/ops/v1alpha1/qdrant_ops_types.go
+++ b/apis/ops/v1alpha1/qdrant_ops_types.go
@@ -108,6 +108,10 @@ type QdrantHorizontalScalingSpec struct {
 type QdrantVerticalScalingSpec struct {
 	// Resource spec for nodes
 	Node *PodResources `json:"node,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // QdrantVolumeExpansionSpec is the spec for Qdrant volume expansion

--- a/apis/ops/v1alpha1/rabbitmq_ops_types.go
+++ b/apis/ops/v1alpha1/rabbitmq_ops_types.go
@@ -106,6 +106,10 @@ type RabbitMQHorizontalScalingSpec struct {
 type RabbitMQVerticalScalingSpec struct {
 	// Resource spec for nodes
 	Node *PodResources `json:"node,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // RabbitMQVolumeExpansionSpec is the spec for RabbitMQ volume expansion

--- a/apis/ops/v1alpha1/redis_ops_types.go
+++ b/apis/ops/v1alpha1/redis_ops_types.go
@@ -145,6 +145,10 @@ type RedisVerticalScalingSpec struct {
 	Redis       *PodResources       `json:"redis,omitempty"`
 	Exporter    *ContainerResources `json:"exporter,omitempty"`
 	Coordinator *ContainerResources `json:"coordinator,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 type RedisAclSpec struct {

--- a/apis/ops/v1alpha1/redis_sentinel_ops_types.go
+++ b/apis/ops/v1alpha1/redis_sentinel_ops_types.go
@@ -101,6 +101,10 @@ type RedisSentinelHorizontalScalingSpec struct {
 type RedisSentinelVerticalScalingSpec struct {
 	RedisSentinel *PodResources       `json:"redissentinel,omitempty"`
 	Exporter      *ContainerResources `json:"exporter,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // RedisSentinelVolumeExpansionSpec is the spec for RedisSentinel volume expansion

--- a/apis/ops/v1alpha1/singlestore_ops_types.go
+++ b/apis/ops/v1alpha1/singlestore_ops_types.go
@@ -110,6 +110,10 @@ type SinglestoreVerticalScalingSpec struct {
 	Leaf *PodResources `json:"leaf,omitempty"`
 	// Resource spec for Coordinator container
 	Coordinator *ContainerResources `json:"coordinator,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // SinglestoreVolumeExpansionSpec is the spec for Singlestore volume expansion

--- a/apis/ops/v1alpha1/solr_ops_types.go
+++ b/apis/ops/v1alpha1/solr_ops_types.go
@@ -95,6 +95,10 @@ type SolrVerticalScalingSpec struct {
 	Overseer *PodResources `json:"overseer,omitempty"`
 	// Resource spec for overseer nodes
 	Coordinator *PodResources `json:"coordinator,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 type SolrVolumeExpansionSpec struct {

--- a/apis/ops/v1alpha1/type.go
+++ b/apis/ops/v1alpha1/type.go
@@ -114,6 +114,18 @@ const (
 	VolumeExpansionModeOffline VolumeExpansionMode = "Offline"
 )
 
+// +kubebuilder:validation:Enum=Restart;InPlace
+type VerticalScalingMode string
+
+const (
+	// VerticalScalingModeRestart actuates a vertical scaling by patching the
+	// pod template and restarting the pods (the default, restart-based path).
+	VerticalScalingModeRestart VerticalScalingMode = "Restart"
+	// VerticalScalingModeInPlace actuates a vertical scaling in place via the
+	// pods/resize subresource, falling back to restart when infeasible.
+	VerticalScalingModeInPlace VerticalScalingMode = "InPlace"
+)
+
 type RestartSpec struct{}
 
 type Reprovision struct{}

--- a/apis/ops/v1alpha1/weaviate_ops_types.go
+++ b/apis/ops/v1alpha1/weaviate_ops_types.go
@@ -107,6 +107,10 @@ type WeaviateHorizontalScalingSpec struct {
 type WeaviateVerticalScalingSpec struct {
 	// Resource spec for nodes
 	Node *PodResources `json:"node,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // WeaviateVolumeExpansionSpec is the spec for Weaviate volume expansion

--- a/apis/ops/v1alpha1/zookeeper_ops_types.go
+++ b/apis/ops/v1alpha1/zookeeper_ops_types.go
@@ -104,6 +104,10 @@ type ZooKeeperHorizontalScalingSpec struct {
 type ZooKeeperVerticalScalingSpec struct {
 	// Resource spec for nodes
 	Node *PodResources `json:"node,omitempty"`
+	// Mode selects how the vertical scaling is actuated. Defaults to Restart.
+	// +optional
+	// +kubebuilder:default=Restart
+	Mode VerticalScalingMode `json:"mode,omitempty"`
 }
 
 // ZooKeeperVolumeExpansionSpec is the spec for ZooKeeper volume expansion

--- a/crds/ops.kubedb.com_aerospikeopsrequests.yaml
+++ b/crds/ops.kubedb.com_aerospikeopsrequests.yaml
@@ -154,6 +154,12 @@ spec:
                             type: object
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                 type: object
             required:
             - databaseRef

--- a/crds/ops.kubedb.com_cassandraopsrequests.yaml
+++ b/crds/ops.kubedb.com_cassandraopsrequests.yaml
@@ -267,6 +267,12 @@ spec:
                 type: object
               verticalScaling:
                 properties:
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   node:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_clickhouseopsrequests.yaml
+++ b/crds/ops.kubedb.com_clickhouseopsrequests.yaml
@@ -271,6 +271,12 @@ spec:
                 type: object
               verticalScaling:
                 properties:
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   node:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_db2opsrequests.yaml
+++ b/crds/ops.kubedb.com_db2opsrequests.yaml
@@ -154,6 +154,12 @@ spec:
                             type: object
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                 type: object
             required:
             - databaseRef

--- a/crds/ops.kubedb.com_documentdbopsrequests.yaml
+++ b/crds/ops.kubedb.com_documentdbopsrequests.yaml
@@ -697,6 +697,12 @@ spec:
                             type: object
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   readReplicas:
                     items:
                       properties:

--- a/crds/ops.kubedb.com_druidopsrequests.yaml
+++ b/crds/ops.kubedb.com_druidopsrequests.yaml
@@ -453,6 +453,12 @@ spec:
                         - value
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   overlords:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_elasticsearchopsrequests.yaml
+++ b/crds/ops.kubedb.com_elasticsearchopsrequests.yaml
@@ -906,6 +906,12 @@ spec:
                         - value
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   node:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_hanadbopsrequests.yaml
+++ b/crds/ops.kubedb.com_hanadbopsrequests.yaml
@@ -350,6 +350,12 @@ spec:
                         - value
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                 type: object
               volumeExpansion:
                 properties:

--- a/crds/ops.kubedb.com_hazelcastopsrequests.yaml
+++ b/crds/ops.kubedb.com_hazelcastopsrequests.yaml
@@ -291,6 +291,12 @@ spec:
                         - value
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                 type: object
               volumeExpansion:
                 properties:

--- a/crds/ops.kubedb.com_igniteopsrequests.yaml
+++ b/crds/ops.kubedb.com_igniteopsrequests.yaml
@@ -243,6 +243,12 @@ spec:
                 type: object
               verticalScaling:
                 properties:
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   node:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_kafkaopsrequests.yaml
+++ b/crds/ops.kubedb.com_kafkaopsrequests.yaml
@@ -369,6 +369,12 @@ spec:
                         - value
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   node:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_mariadbopsrequests.yaml
+++ b/crds/ops.kubedb.com_mariadbopsrequests.yaml
@@ -420,6 +420,12 @@ spec:
                         - value
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                 type: object
               volumeExpansion:
                 properties:

--- a/crds/ops.kubedb.com_memcachedopsrequests.yaml
+++ b/crds/ops.kubedb.com_memcachedopsrequests.yaml
@@ -319,6 +319,12 @@ spec:
                         - value
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   readinessCriteria:
                     type: object
                 type: object

--- a/crds/ops.kubedb.com_milvusopsrequests.yaml
+++ b/crds/ops.kubedb.com_milvusopsrequests.yaml
@@ -372,6 +372,12 @@ spec:
                         - value
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   node:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_mongodbopsrequests.yaml
+++ b/crds/ops.kubedb.com_mongodbopsrequests.yaml
@@ -713,6 +713,12 @@ spec:
                         - value
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   mongos:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_mssqlserveropsrequests.yaml
+++ b/crds/ops.kubedb.com_mssqlserveropsrequests.yaml
@@ -365,6 +365,12 @@ spec:
                             type: object
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   mssqlserver:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_mysqlopsrequests.yaml
+++ b/crds/ops.kubedb.com_mysqlopsrequests.yaml
@@ -431,6 +431,12 @@ spec:
                             type: object
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   mysql:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_neo4jopsrequests.yaml
+++ b/crds/ops.kubedb.com_neo4jopsrequests.yaml
@@ -314,6 +314,12 @@ spec:
                 type: object
               verticalScaling:
                 properties:
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   server:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_oracleopsrequests.yaml
+++ b/crds/ops.kubedb.com_oracleopsrequests.yaml
@@ -127,6 +127,12 @@ spec:
                 type: string
               verticalScaling:
                 properties:
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   node:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_perconaxtradbopsrequests.yaml
+++ b/crds/ops.kubedb.com_perconaxtradbopsrequests.yaml
@@ -320,6 +320,12 @@ spec:
                             type: object
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   perconaxtradb:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_pgbounceropsrequests.yaml
+++ b/crds/ops.kubedb.com_pgbounceropsrequests.yaml
@@ -282,6 +282,12 @@ spec:
                             type: object
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   pgbouncer:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_pgpoolopsrequests.yaml
+++ b/crds/ops.kubedb.com_pgpoolopsrequests.yaml
@@ -273,6 +273,12 @@ spec:
                 type: object
               verticalScaling:
                 properties:
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   node:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_postgresopsrequests.yaml
+++ b/crds/ops.kubedb.com_postgresopsrequests.yaml
@@ -664,6 +664,12 @@ spec:
                             type: object
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   postgres:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_proxysqlopsrequests.yaml
+++ b/crds/ops.kubedb.com_proxysqlopsrequests.yaml
@@ -276,6 +276,12 @@ spec:
                 type: object
               verticalScaling:
                 properties:
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   proxysql:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_qdrantopsrequests.yaml
+++ b/crds/ops.kubedb.com_qdrantopsrequests.yaml
@@ -247,6 +247,12 @@ spec:
                 type: object
               verticalScaling:
                 properties:
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   node:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_rabbitmqopsrequests.yaml
+++ b/crds/ops.kubedb.com_rabbitmqopsrequests.yaml
@@ -243,6 +243,12 @@ spec:
                 type: object
               verticalScaling:
                 properties:
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   node:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_redisopsrequests.yaml
+++ b/crds/ops.kubedb.com_redisopsrequests.yaml
@@ -404,6 +404,12 @@ spec:
                             type: object
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   redis:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_redissentinelopsrequests.yaml
+++ b/crds/ops.kubedb.com_redissentinelopsrequests.yaml
@@ -263,6 +263,12 @@ spec:
                             type: object
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   redissentinel:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_singlestoreopsrequests.yaml
+++ b/crds/ops.kubedb.com_singlestoreopsrequests.yaml
@@ -448,6 +448,12 @@ spec:
                         - value
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   node:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_solropsrequests.yaml
+++ b/crds/ops.kubedb.com_solropsrequests.yaml
@@ -378,6 +378,12 @@ spec:
                         - value
                         type: object
                     type: object
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   node:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_weaviateopsrequests.yaml
+++ b/crds/ops.kubedb.com_weaviateopsrequests.yaml
@@ -246,6 +246,12 @@ spec:
                 type: string
               verticalScaling:
                 properties:
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   node:
                     properties:
                       nodeSelectionPolicy:

--- a/crds/ops.kubedb.com_zookeeperopsrequests.yaml
+++ b/crds/ops.kubedb.com_zookeeperopsrequests.yaml
@@ -233,6 +233,12 @@ spec:
                 type: object
               verticalScaling:
                 properties:
+                  mode:
+                    default: Restart
+                    enum:
+                    - Restart
+                    - InPlace
+                    type: string
                   node:
                     properties:
                       nodeSelectionPolicy:

--- a/openapi/swagger.json
+++ b/openapi/swagger.json
@@ -26040,6 +26040,10 @@
         "ml": {
           "$ref": "#/definitions/dev.kubedb.apimachinery.apis.ops.v1alpha1.PodResources"
         },
+        "mode": {
+          "description": "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+          "type": "string"
+        },
         "node": {
           "description": "Resource spec for combined nodes",
           "$ref": "#/definitions/dev.kubedb.apimachinery.apis.ops.v1alpha1.PodResources"
@@ -26296,6 +26300,10 @@
         },
         "memcached": {
           "$ref": "#/definitions/dev.kubedb.apimachinery.apis.ops.v1alpha1.PodResources"
+        },
+        "mode": {
+          "description": "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+          "type": "string"
         },
         "readinessCriteria": {
           "$ref": "#/definitions/dev.kubedb.apimachinery.apis.ops.v1alpha1.MemcachedReplicaReadinessCriteria"
@@ -26584,6 +26592,10 @@
         },
         "hidden": {
           "$ref": "#/definitions/dev.kubedb.apimachinery.apis.ops.v1alpha1.PodResources"
+        },
+        "mode": {
+          "description": "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+          "type": "string"
         },
         "mongos": {
           "$ref": "#/definitions/dev.kubedb.apimachinery.apis.ops.v1alpha1.PodResources"
@@ -26905,6 +26917,10 @@
         "exporter": {
           "$ref": "#/definitions/dev.kubedb.apimachinery.apis.ops.v1alpha1.ContainerResources"
         },
+        "mode": {
+          "description": "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+          "type": "string"
+        },
         "mysql": {
           "$ref": "#/definitions/dev.kubedb.apimachinery.apis.ops.v1alpha1.PodResources"
         }
@@ -27151,6 +27167,10 @@
         },
         "exporter": {
           "$ref": "#/definitions/dev.kubedb.apimachinery.apis.ops.v1alpha1.ContainerResources"
+        },
+        "mode": {
+          "description": "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+          "type": "string"
         },
         "perconaxtradb": {
           "$ref": "#/definitions/dev.kubedb.apimachinery.apis.ops.v1alpha1.PodResources"
@@ -27499,6 +27519,10 @@
         "exporter": {
           "$ref": "#/definitions/dev.kubedb.apimachinery.apis.ops.v1alpha1.ContainerResources"
         },
+        "mode": {
+          "description": "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+          "type": "string"
+        },
         "postgres": {
           "$ref": "#/definitions/dev.kubedb.apimachinery.apis.ops.v1alpha1.PodResources"
         },
@@ -27704,6 +27728,10 @@
       "description": "ProxySQLVerticalScalingSpec is the spec for ProxySQL vertical scaling",
       "type": "object",
       "properties": {
+        "mode": {
+          "description": "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+          "type": "string"
+        },
         "proxysql": {
           "$ref": "#/definitions/dev.kubedb.apimachinery.apis.ops.v1alpha1.PodResources"
         }
@@ -28101,6 +28129,10 @@
         },
         "exporter": {
           "$ref": "#/definitions/dev.kubedb.apimachinery.apis.ops.v1alpha1.ContainerResources"
+        },
+        "mode": {
+          "description": "Mode selects how the vertical scaling is actuated. Defaults to Restart.",
+          "type": "string"
         },
         "redis": {
           "$ref": "#/definitions/dev.kubedb.apimachinery.apis.ops.v1alpha1.PodResources"

--- a/pkg/lib/inplace_resize.go
+++ b/pkg/lib/inplace_resize.go
@@ -24,14 +24,14 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // InPlaceResizePod requests an in-place resize of the running pod's containers through
 // the pods/resize subresource. targets maps a container name to its desired resources.
 // It does not wait for the resize to be enacted; use IsResizeSettled/IsResizeInfeasible
 // against a freshly fetched pod for that.
-func InPlaceResizePod(kc kubernetes.Interface, namespace, podName string, targets map[string]core.ResourceRequirements) error {
+func InPlaceResizePod(ctx context.Context, kc client.Client, namespace, podName string, targets map[string]core.ResourceRequirements) error {
 	type containerPatch struct {
 		Name      string                    `json:"name"`
 		Resources core.ResourceRequirements `json:"resources"`
@@ -49,9 +49,8 @@ func InPlaceResizePod(kc kubernetes.Interface, namespace, podName string, target
 	if err != nil {
 		return err
 	}
-	_, err = kc.CoreV1().Pods(namespace).Patch(
-		context.TODO(), podName, apitypes.StrategicMergePatchType, data, metav1.PatchOptions{}, "resize")
-	return err
+	pod := &core.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace}}
+	return kc.SubResource("resize").Patch(ctx, pod, client.RawPatch(apitypes.StrategicMergePatchType, data))
 }
 
 // ResizeTargets returns the desired resources keyed by container name for the named

--- a/pkg/lib/inplace_resize.go
+++ b/pkg/lib/inplace_resize.go
@@ -1,0 +1,136 @@
+/*
+Copyright AppsCode Inc. and Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib
+
+import (
+	"context"
+	"encoding/json"
+
+	core "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// InPlaceResizePod requests an in-place resize of the running pod's containers through
+// the pods/resize subresource. targets maps a container name to its desired resources.
+// It does not wait for the resize to be enacted; use IsResizeSettled/IsResizeInfeasible
+// against a freshly fetched pod for that.
+func InPlaceResizePod(kc kubernetes.Interface, namespace, podName string, targets map[string]core.ResourceRequirements) error {
+	type containerPatch struct {
+		Name      string                    `json:"name"`
+		Resources core.ResourceRequirements `json:"resources"`
+	}
+	containers := make([]containerPatch, 0, len(targets))
+	for name, res := range targets {
+		containers = append(containers, containerPatch{Name: name, Resources: res})
+	}
+	patch := map[string]any{
+		"spec": map[string]any{
+			"containers": containers,
+		},
+	}
+	data, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+	_, err = kc.CoreV1().Pods(namespace).Patch(
+		context.TODO(), podName, apitypes.StrategicMergePatchType, data, metav1.PatchOptions{}, "resize")
+	return err
+}
+
+// ResizeTargets returns the desired resources keyed by container name for the named
+// containers found in the given container list (typically a PetSet/StatefulSet template).
+// Names that are not present in the list are skipped.
+func ResizeTargets(containers []core.Container, names ...string) map[string]core.ResourceRequirements {
+	want := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		want[n] = struct{}{}
+	}
+	res := make(map[string]core.ResourceRequirements)
+	for _, ctr := range containers {
+		if _, ok := want[ctr.Name]; ok {
+			res[ctr.Name] = ctr.Resources
+		}
+	}
+	return res
+}
+
+// IsResizeInfeasible reports whether the kubelet rejected the requested resize as
+// impossible (PodResizePending with reason Infeasible), returning the condition message.
+func IsResizeInfeasible(pod *core.Pod) (string, bool) {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == core.PodResizePending && cond.Reason == core.PodReasonInfeasible {
+			return cond.Message, true
+		}
+	}
+	return "", false
+}
+
+// IsResizeSettled reports whether no resize is pending or in progress and every target
+// container's node-enacted resources (status.containerStatuses[].resources) equal the
+// desired resources.
+func IsResizeSettled(pod *core.Pod, targets map[string]core.ResourceRequirements) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == core.PodResizePending || cond.Type == core.PodResizeInProgress {
+			return false
+		}
+	}
+	for name, want := range targets {
+		cs := findContainerStatus(pod.Status.ContainerStatuses, name)
+		if cs == nil || cs.Resources == nil || !resourcesEqual(want, *cs.Resources) {
+			return false
+		}
+	}
+	return true
+}
+
+// PodResourcesMatch reports whether the pod spec already carries the desired resources
+// for every target container (i.e. the resize has already been requested).
+func PodResourcesMatch(pod *core.Pod, targets map[string]core.ResourceRequirements) bool {
+	for name, want := range targets {
+		ctr := findContainer(pod.Spec.Containers, name)
+		if ctr == nil || !resourcesEqual(want, ctr.Resources) {
+			return false
+		}
+	}
+	return true
+}
+
+func resourcesEqual(a, b core.ResourceRequirements) bool {
+	return apiequality.Semantic.DeepEqual(a.Requests, b.Requests) &&
+		apiequality.Semantic.DeepEqual(a.Limits, b.Limits)
+}
+
+func findContainer(containers []core.Container, name string) *core.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+func findContainerStatus(statuses []core.ContainerStatus, name string) *core.ContainerStatus {
+	for i := range statuses {
+		if statuses[i].Name == name {
+			return &statuses[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## What

Introduce a `VerticalScalingMode` enum (`Restart` | `InPlace`) in `apis/ops/v1alpha1/type.go` and add a `Mode` field to **every** `*VerticalScalingSpec`.

- `Restart` (default): patches the pod template and restarts pods — existing behavior, unchanged.
- `InPlace`: actuates via the `pods/resize` subresource, falling back to restart when infeasible.

`Mode` defaults to `Restart`, so existing OpsRequests and behavior are unaffected.

## Difference from #1790

#1790 added `VerticalScalingMode` **and** a separate `MemoryResizePolicy` enum (+ a webhook defaulter) to Postgres only. The `MemoryResizePolicy` axis was dropped here: it is non-orthogonal to `Mode` (both gate whether a restart happens, producing contradictory combinations like `InPlace`+`Retune`), its `shared_buffers` semantics are Postgres-specific and wrong for other engines, and whether to retune is better decided by the operator per engine. This PR keeps the single, clean `Mode` axis and applies it uniformly across all databases.

## Notes

- CRDs and generated OpenAPI/schema are intentionally **not** regenerated in this PR; they will be generated separately.
- deepcopy needs no change (the field is a scalar string).