### PR TITLE
courier: add Branch spec.target.issuerRef for branch TLS

### DIFF
--- a/apis/courier/v1alpha1/branch_types.go
+++ b/apis/courier/v1alpha1/branch_types.go
@@ -124,6 +124,13 @@ type BranchTarget struct {
 	// Resources are the cpu/memory requests and limits in the TARGET cluster.
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// IssuerRef references a cert-manager Issuer or ClusterIssuer in the TARGET cluster. TLS secrets are
+	// namespace and cluster scoped, so a branch cannot reuse the source's; when the source Database has
+	// TLS enabled the operator points the branch's TLS at this issuer and KubeDB mints fresh
+	// certificates for the branch. Required for a TLS-enabled source, ignored otherwise.
+	// +optional
+	IssuerRef *corev1.TypedLocalObjectReference `json:"issuerRef,omitempty"`
 }
 
 // BranchSchedule holds the refresh cadence.

--- a/apis/courier/v1alpha1/openapi_generated.go
+++ b/apis/courier/v1alpha1/openapi_generated.go
@@ -33775,12 +33775,18 @@ func schema_apimachinery_apis_courier_v1alpha1_BranchTarget(ref common.Reference
 							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
+					"issuerRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "IssuerRef references a cert-manager Issuer or ClusterIssuer in the TARGET cluster. TLS secrets are namespace and cluster scoped, so a branch cannot reuse the source's; when the source Database has TLS enabled the operator points the branch's TLS at this issuer and KubeDB mints fresh certificates for the branch. Required for a TLS-enabled source, ignored otherwise.",
+							Ref:         ref("k8s.io/api/core/v1.TypedLocalObjectReference"),
+						},
+					},
 				},
 				Required: []string{"cluster", "namespace", "name"},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.ResourceRequirements"},
+			"k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.TypedLocalObjectReference"},
 	}
 }
 

--- a/apis/courier/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/courier/v1alpha1/zz_generated.deepcopy.go
@@ -262,6 +262,11 @@ func (in *BranchStatus) DeepCopy() *BranchStatus {
 func (in *BranchTarget) DeepCopyInto(out *BranchTarget) {
 	*out = *in
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.IssuerRef != nil {
+		in, out := &in.IssuerRef, &out.IssuerRef
+		*out = new(v1.TypedLocalObjectReference)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/crds/courier.kubedb.com_branches.yaml
+++ b/crds/courier.kubedb.com_branches.yaml
@@ -94,6 +94,19 @@ spec:
                 properties:
                   cluster:
                     type: string
+                  issuerRef:
+                    properties:
+                      apiGroup:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                    x-kubernetes-map-type: atomic
                   name:
                     type: string
                   namespace:

--- a/openapi/swagger.json
+++ b/openapi/swagger.json
@@ -23637,6 +23637,10 @@
           "type": "string",
           "default": ""
         },
+        "issuerRef": {
+          "description": "IssuerRef references a cert-manager Issuer or ClusterIssuer in the TARGET cluster. TLS secrets are namespace and cluster scoped, so a branch cannot reuse the source's; when the source Database has TLS enabled the operator points the branch's TLS at this issuer and KubeDB mints fresh certificates for the branch. Required for a TLS-enabled source, ignored otherwise.",
+          "$ref": "#/definitions/io.k8s.api.core.v1.TypedLocalObjectReference"
+        },
         "name": {
           "description": "Name of the target Database.",
           "type": "string",


### PR DESCRIPTION
TLS secrets are namespace and cluster scoped, so a KubeDB Courier branch cannot reuse the source Database's TLS certificates. Add an optional `issuerRef` (a cert-manager Issuer or ClusterIssuer in the target cluster) to `BranchTarget`.

When the source Database has TLS enabled, the Branch operator points the branched Database's `spec.tls.issuerRef` at this issuer so KubeDB mints fresh certificates for the branch rather than copying the source's. Regenerated deepcopy, openapi, and the branches CRD.

Consumed by the KubeDB Courier Branch operator (kubedb/courier) and the kubedb-courier-addon-manager chart (kubedb/installer).