### PR TITLE
Disallow InPlace vertical scaling mode for Neo4j

### DIFF
--- a/pkg/webhooks/ops/v1alpha1/cassandra.go
+++ b/pkg/webhooks/ops/v1alpha1/cassandra.go
@@ -210,6 +210,9 @@ func (w *CassandraOpsRequestCustomWebhook) validateCassandraVerticalScalingOpsRe
 	if verticalScalingSpec.Node == nil {
 		return errors.New("spec.verticalScaling.Node can't be empty")
 	}
+	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
+		return errors.New("in-place vertical scaling is not supported for Cassandra: JVM heap is derived from container resources and requires a pod restart to take effect")
+	}
 
 	return nil
 }

--- a/pkg/webhooks/ops/v1alpha1/cassandra.go
+++ b/pkg/webhooks/ops/v1alpha1/cassandra.go
@@ -68,7 +68,7 @@ func (w *CassandraOpsRequestCustomWebhook) ValidateCreate(ctx context.Context, o
 		return nil, fmt.Errorf("expected an CassandraOpsRequest object but got %T", obj)
 	}
 	cassandraLog.Info("validate create", "name", ops.Name)
-	return nil, w.validateCreateOrUpdate(ops)
+	return w.validateCreateOrUpdate(ops)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -88,19 +88,20 @@ func (w *CassandraOpsRequestCustomWebhook) ValidateUpdate(ctx context.Context, o
 		return nil, err
 	}
 
-	if err := w.validateCreateOrUpdate(ops); err != nil {
-		return nil, err
+	warnings, err := w.validateCreateOrUpdate(ops)
+	if err != nil {
+		return warnings, err
 	}
 
 	if isOpsReqCompleted(ops.Status.Phase) && !isOpsReqCompleted(oldOps.Status.Phase) { // just completed
 		var db olddbapi.Cassandra
 		err := w.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: ops.Spec.DatabaseRef.Name, Namespace: ops.Namespace}, &db)
 		if err != nil {
-			return nil, err
+			return warnings, err
 		}
-		return nil, resumeDatabase(w.DefaultClient, &db)
+		return warnings, resumeDatabase(w.DefaultClient, &db)
 	}
-	return nil, nil
+	return warnings, nil
 }
 
 func validateCassandraOpsRequest(req *opsapi.CassandraOpsRequest, oldReq *opsapi.CassandraOpsRequest) error {
@@ -119,16 +120,17 @@ func (w *CassandraOpsRequestCustomWebhook) ValidateDelete(ctx context.Context, o
 	return nil, nil
 }
 
-func (w *CassandraOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.CassandraOpsRequest) error {
+func (w *CassandraOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.CassandraOpsRequest) (admission.Warnings, error) {
 	if validType, _ := arrays.Contains(opsapi.CassandraOpsRequestTypeNames(), string(req.Spec.Type)); !validType {
-		return field.Invalid(field.NewPath("spec").Child("type"), req.Name,
+		return nil, field.Invalid(field.NewPath("spec").Child("type"), req.Name,
 			fmt.Sprintf("defined OpsRequestType %s is not supported, supported types for Cassandra are %s", req.Spec.Type, strings.Join(opsapi.CassandraOpsRequestTypeNames(), ", ")))
 	}
 	db, err := w.hasDatabaseRef(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	var allErr field.ErrorList
+	var warnings admission.Warnings
 
 	switch opsapi.CassandraOpsRequestType(req.GetRequestType()) {
 	case opsapi.CassandraOpsRequestTypeRestart:
@@ -140,7 +142,9 @@ func (w *CassandraOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.Ca
 				err.Error()))
 		}
 	case opsapi.CassandraOpsRequestTypeVerticalScaling:
-		if err := w.validateCassandraVerticalScalingOpsRequest(req); err != nil {
+		warns, err := w.validateCassandraVerticalScalingOpsRequest(req)
+		warnings = append(warnings, warns...)
+		if err != nil {
 			allErr = append(allErr, field.Invalid(field.NewPath("spec").Child("verticalScaling"),
 				req.Name,
 				err.Error()))
@@ -185,9 +189,9 @@ func (w *CassandraOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.Ca
 	}
 
 	if len(allErr) == 0 {
-		return nil
+		return warnings, nil
 	}
-	return apierrors.NewInvalid(schema.GroupKind{Group: "Cassandraopsrequests.kubedb.com", Kind: "CassandraOpsRequest"}, req.Name, allErr)
+	return warnings, apierrors.NewInvalid(schema.GroupKind{Group: "Cassandraopsrequests.kubedb.com", Kind: "CassandraOpsRequest"}, req.Name, allErr)
 }
 
 func (w *CassandraOpsRequestCustomWebhook) hasDatabaseRef(req *opsapi.CassandraOpsRequest) (*olddbapi.Cassandra, error) {
@@ -201,20 +205,22 @@ func (w *CassandraOpsRequestCustomWebhook) hasDatabaseRef(req *opsapi.CassandraO
 	return cassandra, nil
 }
 
-func (w *CassandraOpsRequestCustomWebhook) validateCassandraVerticalScalingOpsRequest(req *opsapi.CassandraOpsRequest) error {
+func (w *CassandraOpsRequestCustomWebhook) validateCassandraVerticalScalingOpsRequest(req *opsapi.CassandraOpsRequest) (admission.Warnings, error) {
 	verticalScalingSpec := req.Spec.VerticalScaling
 	if verticalScalingSpec == nil {
-		return errors.New("spec.verticalScaling nil not supported in VerticalScaling type")
+		return nil, errors.New("spec.verticalScaling nil not supported in VerticalScaling type")
 	}
 
 	if verticalScalingSpec.Node == nil {
-		return errors.New("spec.verticalScaling.Node can't be empty")
-	}
-	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
-		return errors.New("in-place vertical scaling is not supported for Cassandra: JVM heap is derived from container resources and requires a pod restart to take effect")
+		return nil, errors.New("spec.verticalScaling.Node can't be empty")
 	}
 
-	return nil
+	var warnings admission.Warnings
+	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
+		warnings = append(warnings, "in-place vertical scaling is not recommended for Cassandra: JVM heap is derived from container resources and requires a pod restart to take effect")
+	}
+
+	return warnings, nil
 }
 
 func (w *CassandraOpsRequestCustomWebhook) validateCassandraHorizontalScalingOpsRequest(req *opsapi.CassandraOpsRequest) error {

--- a/pkg/webhooks/ops/v1alpha1/druid.go
+++ b/pkg/webhooks/ops/v1alpha1/druid.go
@@ -68,7 +68,7 @@ func (w *DruidOpsRequestCustomWebhook) ValidateCreate(ctx context.Context, obj r
 		return nil, fmt.Errorf("expected an DruidOpsRequest object but got %T", obj)
 	}
 	druidLog.Info("validate create", "name", ops.Name)
-	return nil, w.validateCreateOrUpdate(ops)
+	return w.validateCreateOrUpdate(ops)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -87,19 +87,20 @@ func (w *DruidOpsRequestCustomWebhook) ValidateUpdate(ctx context.Context, oldOb
 	if err := validateDruidOpsRequest(ops, oldOps); err != nil {
 		return nil, err
 	}
-	if err := w.validateCreateOrUpdate(ops); err != nil {
-		return nil, err
+	warnings, err := w.validateCreateOrUpdate(ops)
+	if err != nil {
+		return warnings, err
 	}
 
 	if isOpsReqCompleted(ops.Status.Phase) && !isOpsReqCompleted(oldOps.Status.Phase) { // just completed
 		var db olddbapi.Druid
 		err := w.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: ops.Spec.DatabaseRef.Name, Namespace: ops.Namespace}, &db)
 		if err != nil {
-			return nil, err
+			return warnings, err
 		}
-		return nil, resumeDatabase(w.DefaultClient, &db)
+		return warnings, resumeDatabase(w.DefaultClient, &db)
 	}
-	return nil, nil
+	return warnings, nil
 }
 
 func (w *DruidOpsRequestCustomWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
@@ -122,17 +123,18 @@ func validateDruidOpsRequest(req *opsapi.DruidOpsRequest, oldReq *opsapi.DruidOp
 	return nil
 }
 
-func (w *DruidOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.DruidOpsRequest) error {
+func (w *DruidOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.DruidOpsRequest) (admission.Warnings, error) {
 	if validType, _ := arrays.Contains(opsapi.DruidOpsRequestTypeNames(), string(req.Spec.Type)); !validType {
-		return field.Invalid(field.NewPath("spec").Child("type"), req.Name,
+		return nil, field.Invalid(field.NewPath("spec").Child("type"), req.Name,
 			fmt.Sprintf("defined OpsRequestType %s is not supported, supported types for Druid are %s", req.Spec.Type, strings.Join(opsapi.DruidOpsRequestTypeNames(), ", ")))
 	}
 	druid, err := w.hasDatabaseRef(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var allErr field.ErrorList
+	var warnings admission.Warnings
 
 	opsType := opsapi.DruidOpsRequestType(req.GetRequestType())
 
@@ -152,7 +154,9 @@ func (w *DruidOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.DruidO
 				err.Error()))
 		}
 	case opsapi.DruidOpsRequestTypeVerticalScaling:
-		if err := w.validateDruidVerticalScalingOpsRequest(req, druid); err != nil {
+		warns, err := w.validateDruidVerticalScalingOpsRequest(req, druid)
+		warnings = append(warnings, warns...)
+		if err != nil {
 			allErr = append(allErr, field.Invalid(field.NewPath("spec").Child("verticalScaling"),
 				req.Name,
 				err.Error()))
@@ -190,9 +194,9 @@ func (w *DruidOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.DruidO
 	}
 
 	if len(allErr) == 0 {
-		return nil
+		return warnings, nil
 	}
-	return apierrors.NewInvalid(schema.GroupKind{Group: "Druidopsrequests.kubedb.com", Kind: "DruidOpsRequest"}, req.Name, allErr)
+	return warnings, apierrors.NewInvalid(schema.GroupKind{Group: "Druidopsrequests.kubedb.com", Kind: "DruidOpsRequest"}, req.Name, allErr)
 }
 
 func (w *DruidOpsRequestCustomWebhook) validateDruidStorageMigrationOpsRequest(req *opsapi.DruidOpsRequest, db *olddbapi.Druid) error {
@@ -304,39 +308,41 @@ func (w *DruidOpsRequestCustomWebhook) validateDruidHorizontalScalingOpsRequest(
 	return nil
 }
 
-func (w *DruidOpsRequestCustomWebhook) validateDruidVerticalScalingOpsRequest(req *opsapi.DruidOpsRequest, druid *olddbapi.Druid) error {
+func (w *DruidOpsRequestCustomWebhook) validateDruidVerticalScalingOpsRequest(req *opsapi.DruidOpsRequest, druid *olddbapi.Druid) (admission.Warnings, error) {
 	verticalScalingSpec := req.Spec.VerticalScaling
 
 	if verticalScalingSpec == nil {
-		return errors.New("spec.verticalScaling nil not supported in VerticalScaling type")
+		return nil, errors.New("spec.verticalScaling nil not supported in VerticalScaling type")
 	}
 	if verticalScalingSpec.Coordinators == nil && verticalScalingSpec.Overlords == nil && verticalScalingSpec.MiddleManagers == nil && verticalScalingSpec.Historicals == nil && verticalScalingSpec.Brokers == nil && verticalScalingSpec.Routers == nil {
-		return errors.New("spec.verticalScaling.topology can not be empty")
+		return nil, errors.New("spec.verticalScaling.topology can not be empty")
 	}
 
 	topology := druid.Spec.Topology
 	if verticalScalingSpec.Coordinators != nil && topology.Coordinators == nil {
-		return errors.New("spec.verticalScaling.Coordinators can not be set as Coordinators does not exist in the database instance")
+		return nil, errors.New("spec.verticalScaling.Coordinators can not be set as Coordinators does not exist in the database instance")
 	}
 	if verticalScalingSpec.Overlords != nil && topology.Overlords == nil {
-		return errors.New("spec.verticalScaling.Overlords can not be set as Overlords does not exist in the database instance")
+		return nil, errors.New("spec.verticalScaling.Overlords can not be set as Overlords does not exist in the database instance")
 	}
 	if verticalScalingSpec.MiddleManagers != nil && topology.MiddleManagers == nil {
-		return errors.New("spec.verticalScaling.MiddleManagers can not be set as MiddleManagers does not exist in the database instance")
+		return nil, errors.New("spec.verticalScaling.MiddleManagers can not be set as MiddleManagers does not exist in the database instance")
 	}
 	if verticalScalingSpec.Historicals != nil && topology.Historicals == nil {
-		return errors.New("spec.verticalScaling.Historicals can not be set as Historicals does not exist in the database instance")
+		return nil, errors.New("spec.verticalScaling.Historicals can not be set as Historicals does not exist in the database instance")
 	}
 	if verticalScalingSpec.Brokers != nil && topology.Brokers == nil {
-		return errors.New("spec.verticalScaling.Brokers can not be set as Brokers does not exist in the database instance")
+		return nil, errors.New("spec.verticalScaling.Brokers can not be set as Brokers does not exist in the database instance")
 	}
 	if verticalScalingSpec.Routers != nil && topology.Routers == nil {
-		return errors.New("spec.verticalScaling.Routers can not be set as Routers does not exist in the database instance")
+		return nil, errors.New("spec.verticalScaling.Routers can not be set as Routers does not exist in the database instance")
 	}
+
+	var warnings admission.Warnings
 	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
-		return errors.New("in-place vertical scaling is not supported for Druid: JVM heap is derived from container resources and requires a pod restart to take effect")
+		warnings = append(warnings, "in-place vertical scaling is not recommended for Druid: JVM heap is derived from container resources and requires a pod restart to take effect")
 	}
-	return nil
+	return warnings, nil
 }
 
 func (w *DruidOpsRequestCustomWebhook) validateDruidVolumeExpansionOpsRequest(req *opsapi.DruidOpsRequest, druid *olddbapi.Druid) error {

--- a/pkg/webhooks/ops/v1alpha1/druid.go
+++ b/pkg/webhooks/ops/v1alpha1/druid.go
@@ -333,6 +333,9 @@ func (w *DruidOpsRequestCustomWebhook) validateDruidVerticalScalingOpsRequest(re
 	if verticalScalingSpec.Routers != nil && topology.Routers == nil {
 		return errors.New("spec.verticalScaling.Routers can not be set as Routers does not exist in the database instance")
 	}
+	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
+		return errors.New("in-place vertical scaling is not supported for Druid: JVM heap is derived from container resources and requires a pod restart to take effect")
+	}
 	return nil
 }
 

--- a/pkg/webhooks/ops/v1alpha1/elasticsearch.go
+++ b/pkg/webhooks/ops/v1alpha1/elasticsearch.go
@@ -190,12 +190,30 @@ func (w *ElasticsearchOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsap
 				req.Name,
 				err.Error()))
 		}
+	case opsapi.ElasticsearchOpsRequestTypeVerticalScaling:
+		if err := w.validateElasticsearchVerticalScalingOpsRequest(req); err != nil {
+			allErr = append(allErr, field.Invalid(field.NewPath("spec").Child("verticalScaling"),
+				req.Name,
+				err.Error()))
+		}
 	}
 
 	if len(allErr) == 0 {
 		return nil
 	}
 	return apierrors.NewInvalid(schema.GroupKind{Group: "elasticsearchopsrequests.kubedb.com", Kind: "ElasticsearchOpsRequest"}, req.Name, allErr)
+}
+
+func (w *ElasticsearchOpsRequestCustomWebhook) validateElasticsearchVerticalScalingOpsRequest(req *opsapi.ElasticsearchOpsRequest) error {
+	verticalScalingSpec := req.Spec.VerticalScaling
+	if verticalScalingSpec == nil {
+		return errors.New("spec.verticalScaling nil not supported in VerticalScaling type")
+	}
+	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
+		return errors.New("in-place vertical scaling is not supported for Elasticsearch: JVM heap (ES_JAVA_OPTS -Xms/-Xmx) is derived from container resources and requires a pod restart to take effect")
+	}
+
+	return nil
 }
 
 func (w *ElasticsearchOpsRequestCustomWebhook) validateElasticsearchUpdateVersionOpsRequest(req *opsapi.ElasticsearchOpsRequest, db *dbapi.Elasticsearch) error {

--- a/pkg/webhooks/ops/v1alpha1/elasticsearch.go
+++ b/pkg/webhooks/ops/v1alpha1/elasticsearch.go
@@ -70,7 +70,7 @@ func (w *ElasticsearchOpsRequestCustomWebhook) ValidateCreate(ctx context.Contex
 		return nil, fmt.Errorf("expected an ElasticsearchOpsRequest object but got %T", obj)
 	}
 	esLog.Info("validate create", "name", ops.Name)
-	return nil, w.validateCreateOrUpdate(ops)
+	return w.validateCreateOrUpdate(ops)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -90,19 +90,20 @@ func (w *ElasticsearchOpsRequestCustomWebhook) ValidateUpdate(ctx context.Contex
 		return nil, err
 	}
 
-	if err := w.validateCreateOrUpdate(ops); err != nil {
-		return nil, err
+	warnings, err := w.validateCreateOrUpdate(ops)
+	if err != nil {
+		return warnings, err
 	}
 
 	if isOpsReqCompleted(ops.Status.Phase) && !isOpsReqCompleted(oldOps.Status.Phase) { // just completed
 		var db dbapi.Elasticsearch
 		err := w.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: ops.Spec.DatabaseRef.Name, Namespace: ops.Namespace}, &db)
 		if err != nil {
-			return nil, err
+			return warnings, err
 		}
-		return nil, resumeDatabase(w.DefaultClient, &db)
+		return warnings, resumeDatabase(w.DefaultClient, &db)
 	}
-	return nil, nil
+	return warnings, nil
 }
 
 func (w *ElasticsearchOpsRequestCustomWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
@@ -144,12 +145,13 @@ func (w *ElasticsearchOpsRequestCustomWebhook) validateOpensearchVersionCompatib
 	return false, nil
 }
 
-func (w *ElasticsearchOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.ElasticsearchOpsRequest) error {
+func (w *ElasticsearchOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.ElasticsearchOpsRequest) (admission.Warnings, error) {
 	if validType, _ := arrays.Contains(opsapi.ElasticsearchOpsRequestTypeNames(), string(req.Spec.Type)); !validType {
-		return field.Invalid(field.NewPath("spec").Child("type"), req.Name,
+		return nil, field.Invalid(field.NewPath("spec").Child("type"), req.Name,
 			fmt.Sprintf("defined OpsRequestType %s is not supported, supported types for Elasticsearch are %s", req.Spec.Type, strings.Join(opsapi.ElasticsearchOpsRequestTypeNames(), ", ")))
 	}
 	var allErr field.ErrorList
+	var warnings admission.Warnings
 	db := &dbapi.Elasticsearch{}
 	err := w.DefaultClient.Get(context.TODO(), types.NamespacedName{
 		Name:      req.GetDBRefName(),
@@ -191,7 +193,9 @@ func (w *ElasticsearchOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsap
 				err.Error()))
 		}
 	case opsapi.ElasticsearchOpsRequestTypeVerticalScaling:
-		if err := w.validateElasticsearchVerticalScalingOpsRequest(req); err != nil {
+		warns, err := w.validateElasticsearchVerticalScalingOpsRequest(req)
+		warnings = append(warnings, warns...)
+		if err != nil {
 			allErr = append(allErr, field.Invalid(field.NewPath("spec").Child("verticalScaling"),
 				req.Name,
 				err.Error()))
@@ -199,21 +203,23 @@ func (w *ElasticsearchOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsap
 	}
 
 	if len(allErr) == 0 {
-		return nil
+		return warnings, nil
 	}
-	return apierrors.NewInvalid(schema.GroupKind{Group: "elasticsearchopsrequests.kubedb.com", Kind: "ElasticsearchOpsRequest"}, req.Name, allErr)
+	return warnings, apierrors.NewInvalid(schema.GroupKind{Group: "elasticsearchopsrequests.kubedb.com", Kind: "ElasticsearchOpsRequest"}, req.Name, allErr)
 }
 
-func (w *ElasticsearchOpsRequestCustomWebhook) validateElasticsearchVerticalScalingOpsRequest(req *opsapi.ElasticsearchOpsRequest) error {
+func (w *ElasticsearchOpsRequestCustomWebhook) validateElasticsearchVerticalScalingOpsRequest(req *opsapi.ElasticsearchOpsRequest) (admission.Warnings, error) {
 	verticalScalingSpec := req.Spec.VerticalScaling
 	if verticalScalingSpec == nil {
-		return errors.New("spec.verticalScaling nil not supported in VerticalScaling type")
-	}
-	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
-		return errors.New("in-place vertical scaling is not supported for Elasticsearch: JVM heap (ES_JAVA_OPTS -Xms/-Xmx) is derived from container resources and requires a pod restart to take effect")
+		return nil, errors.New("spec.verticalScaling nil not supported in VerticalScaling type")
 	}
 
-	return nil
+	var warnings admission.Warnings
+	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
+		warnings = append(warnings, "in-place vertical scaling is not recommended for Elasticsearch: JVM heap (ES_JAVA_OPTS -Xms/-Xmx) is derived from container resources and requires a pod restart to take effect")
+	}
+
+	return warnings, nil
 }
 
 func (w *ElasticsearchOpsRequestCustomWebhook) validateElasticsearchUpdateVersionOpsRequest(req *opsapi.ElasticsearchOpsRequest, db *dbapi.Elasticsearch) error {

--- a/pkg/webhooks/ops/v1alpha1/kafka.go
+++ b/pkg/webhooks/ops/v1alpha1/kafka.go
@@ -269,6 +269,9 @@ func (w *KafkaOpsRequestCustomWebhook) validateKafkaVerticalScalingOpsRequest(ka
 	if kafka.Spec.Topology == nil && verticalScalingSpec.Node == nil {
 		return errors.New("spec.verticalScaling.node can not be empty as reference database mode is combined")
 	}
+	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
+		return errors.New("in-place vertical scaling is not supported for Kafka: JVM heap is derived from container resources and requires a pod restart to take effect")
+	}
 
 	return nil
 }

--- a/pkg/webhooks/ops/v1alpha1/kafka.go
+++ b/pkg/webhooks/ops/v1alpha1/kafka.go
@@ -68,7 +68,7 @@ func (w *KafkaOpsRequestCustomWebhook) ValidateCreate(ctx context.Context, obj r
 		return nil, fmt.Errorf("expected an KafkaOpsRequest object but got %T", obj)
 	}
 	kafkaLog.Info("validate create", "name", ops.Name)
-	return nil, w.validateCreateOrUpdate(ops)
+	return w.validateCreateOrUpdate(ops)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -87,19 +87,20 @@ func (w *KafkaOpsRequestCustomWebhook) ValidateUpdate(ctx context.Context, oldOb
 	if err := validateKafkaOpsRequest(ops, oldOps); err != nil {
 		return nil, err
 	}
-	if err := w.validateCreateOrUpdate(ops); err != nil {
-		return nil, err
+	warnings, err := w.validateCreateOrUpdate(ops)
+	if err != nil {
+		return warnings, err
 	}
 
 	if isOpsReqCompleted(ops.Status.Phase) && !isOpsReqCompleted(oldOps.Status.Phase) { // just completed
 		var db dbapi.Kafka
 		err := w.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: ops.Spec.DatabaseRef.Name, Namespace: ops.Namespace}, &db)
 		if err != nil {
-			return nil, err
+			return warnings, err
 		}
-		return nil, resumeDatabase(w.DefaultClient, &db)
+		return warnings, resumeDatabase(w.DefaultClient, &db)
 	}
-	return nil, nil
+	return warnings, nil
 }
 
 func (w *KafkaOpsRequestCustomWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
@@ -122,9 +123,9 @@ func validateKafkaOpsRequest(req *opsapi.KafkaOpsRequest, oldReq *opsapi.KafkaOp
 	return nil
 }
 
-func (w *KafkaOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.KafkaOpsRequest) error {
+func (w *KafkaOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.KafkaOpsRequest) (admission.Warnings, error) {
 	if validType, _ := arrays.Contains(opsapi.KafkaOpsRequestTypeNames(), string(req.Spec.Type)); !validType {
-		return field.Invalid(field.NewPath("spec").Child("type"), req.Name,
+		return nil, field.Invalid(field.NewPath("spec").Child("type"), req.Name,
 			fmt.Sprintf("defined OpsRequestType %s is not supported, supported types for Kafka are %s", req.Spec.Type, strings.Join(opsapi.KafkaOpsRequestTypeNames(), ", ")))
 	}
 
@@ -133,10 +134,11 @@ func (w *KafkaOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.KafkaO
 		kafka *dbapi.Kafka
 	)
 	if kafka, err = w.hasDatabaseRef(req); err != nil {
-		return err
+		return nil, err
 	}
 
 	var allErr field.ErrorList
+	var warnings admission.Warnings
 	switch opsapi.KafkaOpsRequestType(req.GetRequestType()) {
 	case opsapi.KafkaOpsRequestTypeUpdateVersion:
 		if err := w.validateKafkaUpdateVersionOpsRequest(kafka, req); err != nil {
@@ -151,7 +153,9 @@ func (w *KafkaOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.KafkaO
 				err.Error()))
 		}
 	case opsapi.KafkaOpsRequestTypeVerticalScaling:
-		if err := w.validateKafkaVerticalScalingOpsRequest(kafka, req); err != nil {
+		warns, err := w.validateKafkaVerticalScalingOpsRequest(kafka, req)
+		warnings = append(warnings, warns...)
+		if err != nil {
 			allErr = append(allErr, field.Invalid(field.NewPath("spec").Child("verticalScaling"),
 				req.Name,
 				err.Error()))
@@ -189,9 +193,9 @@ func (w *KafkaOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.KafkaO
 	}
 
 	if len(allErr) == 0 {
-		return nil
+		return warnings, nil
 	}
-	return apierrors.NewInvalid(schema.GroupKind{Group: "kafkaopsrequests.kubedb.com", Kind: "KafkaOpsRequest"}, req.Name, allErr)
+	return warnings, apierrors.NewInvalid(schema.GroupKind{Group: "kafkaopsrequests.kubedb.com", Kind: "KafkaOpsRequest"}, req.Name, allErr)
 }
 
 func (w *KafkaOpsRequestCustomWebhook) hasDatabaseRef(req *opsapi.KafkaOpsRequest) (*dbapi.Kafka, error) {
@@ -254,26 +258,28 @@ func (w *KafkaOpsRequestCustomWebhook) validateKafkaHorizontalScalingOpsRequest(
 	return nil
 }
 
-func (w *KafkaOpsRequestCustomWebhook) validateKafkaVerticalScalingOpsRequest(kafka *dbapi.Kafka, req *opsapi.KafkaOpsRequest) error {
+func (w *KafkaOpsRequestCustomWebhook) validateKafkaVerticalScalingOpsRequest(kafka *dbapi.Kafka, req *opsapi.KafkaOpsRequest) (admission.Warnings, error) {
 	verticalScalingSpec := req.Spec.VerticalScaling
 	if verticalScalingSpec == nil {
-		return errors.New("spec.verticalScaling nil not supported in VerticalScaling type")
+		return nil, errors.New("spec.verticalScaling nil not supported in VerticalScaling type")
 	}
 
 	if (verticalScalingSpec.Broker != nil || verticalScalingSpec.Controller != nil) && verticalScalingSpec.Node != nil {
-		return errors.New("spec.verticalScaling.Node && spec.verticalScaling.Topology both can't be non-empty at the same ops request")
+		return nil, errors.New("spec.verticalScaling.Node && spec.verticalScaling.Topology both can't be non-empty at the same ops request")
 	}
 	if kafka.Spec.Topology != nil && verticalScalingSpec.Broker == nil && verticalScalingSpec.Controller == nil {
-		return errors.New("spec.verticalScaling.topology can not be empty as reference database mode is topology")
+		return nil, errors.New("spec.verticalScaling.topology can not be empty as reference database mode is topology")
 	}
 	if kafka.Spec.Topology == nil && verticalScalingSpec.Node == nil {
-		return errors.New("spec.verticalScaling.node can not be empty as reference database mode is combined")
-	}
-	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
-		return errors.New("in-place vertical scaling is not supported for Kafka: JVM heap is derived from container resources and requires a pod restart to take effect")
+		return nil, errors.New("spec.verticalScaling.node can not be empty as reference database mode is combined")
 	}
 
-	return nil
+	var warnings admission.Warnings
+	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
+		warnings = append(warnings, "in-place vertical scaling is not recommended for Kafka: JVM heap is derived from container resources and requires a pod restart to take effect")
+	}
+
+	return warnings, nil
 }
 
 func (w *KafkaOpsRequestCustomWebhook) validateKafkaVolumeExpansionOpsRequest(kafka *dbapi.Kafka, req *opsapi.KafkaOpsRequest) error {

--- a/pkg/webhooks/ops/v1alpha1/neo4j.go
+++ b/pkg/webhooks/ops/v1alpha1/neo4j.go
@@ -470,6 +470,9 @@ func (w *Neo4jOpsRequestCustomWebhook) validateNeo4jVerticalScalingOpsRequest(re
 	if verticalScalingSpec.Server == nil {
 		return errors.New("`spec.verticalScaling.Server`,should be present in vertical scaling ops request")
 	}
+	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
+		return errors.New("in-place vertical scaling is not supported for Neo4j: memory settings (server.memory.heap.*, server.memory.pagecache.size) require a pod restart to take effect")
+	}
 
 	return nil
 }

--- a/pkg/webhooks/ops/v1alpha1/neo4j.go
+++ b/pkg/webhooks/ops/v1alpha1/neo4j.go
@@ -70,7 +70,7 @@ func (w *Neo4jOpsRequestCustomWebhook) ValidateCreate(ctx context.Context, obj r
 		return nil, fmt.Errorf("expected an Neo4jOpsRequest object but got %T", obj)
 	}
 	neo4jLog.Info("validate create", "name", req.Name)
-	return nil, w.validateCreateOrUpdate(req)
+	return w.validateCreateOrUpdate(req)
 }
 
 func (w *Neo4jOpsRequestCustomWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
@@ -88,18 +88,19 @@ func (w *Neo4jOpsRequestCustomWebhook) ValidateUpdate(ctx context.Context, oldOb
 	if err := validateNeo4jOpsRequest(req, oldReq); err != nil {
 		return nil, err
 	}
-	if err := w.validateCreateOrUpdate(req); err != nil {
-		return nil, err
+	warnings, err := w.validateCreateOrUpdate(req)
+	if err != nil {
+		return warnings, err
 	}
 	if isOpsReqCompleted(req.Status.Phase) && !isOpsReqCompleted(oldReq.Status.Phase) { // just completed
 		var db dbapi.Neo4j
 		err := w.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: req.Spec.DatabaseRef.Name, Namespace: req.Namespace}, &db)
 		if err != nil {
-			return nil, err
+			return warnings, err
 		}
-		return nil, resumeDatabase(w.DefaultClient, &db)
+		return warnings, resumeDatabase(w.DefaultClient, &db)
 	}
-	return nil, nil
+	return warnings, nil
 }
 
 func (w *Neo4jOpsRequestCustomWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
@@ -122,18 +123,19 @@ func validateNeo4jOpsRequest(req *opsapi.Neo4jOpsRequest, oldReq *opsapi.Neo4jOp
 	return nil
 }
 
-func (w *Neo4jOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.Neo4jOpsRequest) error {
+func (w *Neo4jOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.Neo4jOpsRequest) (admission.Warnings, error) {
 	if validType, _ := arrays.Contains(opsapi.Neo4jOpsRequestTypeNames(), string(req.Spec.Type)); !validType {
-		return field.Invalid(field.NewPath("spec").Child("type"), req.Name,
+		return nil, field.Invalid(field.NewPath("spec").Child("type"), req.Name,
 			fmt.Sprintf("defined OpsRequestType %s is not supported, supported types for Neo4j are %s", req.Spec.Type, strings.Join(opsapi.Neo4jOpsRequestTypeNames(), ", ")))
 	}
 
 	neo4j, err := w.hasDatabaseRef(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var allErr field.ErrorList
+	var warnings admission.Warnings
 	switch opsapi.Neo4jOpsRequestType(req.GetRequestType()) {
 	case opsapi.Neo4jOpsRequestTypeHorizontalScaling:
 		if err := w.validateNeo4jHorizontalScalingOpsRequest(neo4j, req); err != nil {
@@ -152,7 +154,9 @@ func (w *Neo4jOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.Neo4jO
 			allErr = append(allErr, field.Invalid(field.NewPath("spec").Child("configuration"), req.Name, err.Error()))
 		}
 	case opsapi.Neo4jOpsRequestTypeVerticalScaling:
-		if err := w.validateNeo4jVerticalScalingOpsRequest(req); err != nil {
+		warns, err := w.validateNeo4jVerticalScalingOpsRequest(req)
+		warnings = append(warnings, warns...)
+		if err != nil {
 			allErr = append(allErr, field.Invalid(field.NewPath("spec").Child("configuration"), req.Name, err.Error()))
 		}
 	case opsapi.Neo4jOpsRequestTypeUpdateVersion:
@@ -172,9 +176,9 @@ func (w *Neo4jOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.Neo4jO
 	}
 
 	if len(allErr) == 0 {
-		return nil
+		return warnings, nil
 	}
-	return apierrors.NewInvalid(schema.GroupKind{Group: "neo4jopsrequests.kubedb.com", Kind: "Neo4jOpsRequest"}, req.Name, allErr)
+	return warnings, apierrors.NewInvalid(schema.GroupKind{Group: "neo4jopsrequests.kubedb.com", Kind: "Neo4jOpsRequest"}, req.Name, allErr)
 }
 
 func (w *Neo4jOpsRequestCustomWebhook) validateNeo4jStorageMigrationOpsRequest(req *opsapi.Neo4jOpsRequest) error {
@@ -462,19 +466,21 @@ func compareVersion(current, target *CalVersionInfo) int {
 	return 0
 }
 
-func (w *Neo4jOpsRequestCustomWebhook) validateNeo4jVerticalScalingOpsRequest(req *opsapi.Neo4jOpsRequest) error {
+func (w *Neo4jOpsRequestCustomWebhook) validateNeo4jVerticalScalingOpsRequest(req *opsapi.Neo4jOpsRequest) (admission.Warnings, error) {
 	verticalScalingSpec := req.Spec.VerticalScaling
 	if verticalScalingSpec == nil {
-		return errors.New("spec.verticalScaling nil not supported in VerticalScaling type")
+		return nil, errors.New("spec.verticalScaling nil not supported in VerticalScaling type")
 	}
 	if verticalScalingSpec.Server == nil {
-		return errors.New("`spec.verticalScaling.Server`,should be present in vertical scaling ops request")
-	}
-	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
-		return errors.New("in-place vertical scaling is not supported for Neo4j: memory settings (server.memory.heap.*, server.memory.pagecache.size) require a pod restart to take effect")
+		return nil, errors.New("`spec.verticalScaling.Server`,should be present in vertical scaling ops request")
 	}
 
-	return nil
+	var warnings admission.Warnings
+	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
+		warnings = append(warnings, "in-place vertical scaling is not recommended for Neo4j: memory settings (server.memory.heap.*, server.memory.pagecache.size) require a pod restart to take effect")
+	}
+
+	return warnings, nil
 }
 
 func (w *Neo4jOpsRequestCustomWebhook) hasDatabaseRef(req *opsapi.Neo4jOpsRequest) (*dbapi.Neo4j, error) {

--- a/pkg/webhooks/ops/v1alpha1/solr.go
+++ b/pkg/webhooks/ops/v1alpha1/solr.go
@@ -68,7 +68,7 @@ func (w *SolrOpsRequestCustomWebhook) ValidateCreate(ctx context.Context, obj ru
 		return nil, fmt.Errorf("expected an SolrOpsRequest object but got %T", obj)
 	}
 	slLog.Info("validate create", "name", ops.Name)
-	return nil, w.validateCreateOrUpdate(ops)
+	return w.validateCreateOrUpdate(ops)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -87,18 +87,19 @@ func (w *SolrOpsRequestCustomWebhook) ValidateUpdate(ctx context.Context, oldObj
 	if err := validateSolrOpsRequest(ops, oldOps); err != nil {
 		return nil, err
 	}
-	if err := w.validateCreateOrUpdate(ops); err != nil {
-		return nil, err
+	warnings, err := w.validateCreateOrUpdate(ops)
+	if err != nil {
+		return warnings, err
 	}
 	if isOpsReqCompleted(ops.Status.Phase) && !isOpsReqCompleted(oldOps.Status.Phase) { // just completed
 		var db olddbapi.Solr
 		err := w.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: ops.Spec.DatabaseRef.Name, Namespace: ops.Namespace}, &db)
 		if err != nil {
-			return nil, err
+			return warnings, err
 		}
-		return nil, resumeDatabase(w.DefaultClient, &db)
+		return warnings, resumeDatabase(w.DefaultClient, &db)
 	}
-	return nil, nil
+	return warnings, nil
 }
 
 func (w *SolrOpsRequestCustomWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
@@ -117,17 +118,18 @@ func validateSolrOpsRequest(req *opsapi.SolrOpsRequest, oldReq *opsapi.SolrOpsRe
 	return nil
 }
 
-func (w *SolrOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.SolrOpsRequest) error {
+func (w *SolrOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.SolrOpsRequest) (admission.Warnings, error) {
 	if validType, _ := arrays.Contains(opsapi.SolrOpsRequestTypeNames(), string(req.Spec.Type)); !validType {
-		return field.Invalid(field.NewPath("spec").Child("type"), req.Name,
+		return nil, field.Invalid(field.NewPath("spec").Child("type"), req.Name,
 			fmt.Sprintf("defined OpsRequestType %s is not supported, supported types for Solr are %s", req.Spec.Type, strings.Join(opsapi.SolrOpsRequestTypeNames(), ", ")))
 	}
 	db, err := w.hasDatabaseRef(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var allErr field.ErrorList
+	var warnings admission.Warnings
 	switch opsapi.SolrOpsRequestType(req.GetRequestType()) {
 	case opsapi.SolrOpsRequestTypeRestart:
 
@@ -146,7 +148,9 @@ func (w *SolrOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.SolrOps
 				err.Error()))
 		}
 	case opsapi.SolrOpsRequestTypeVerticalScaling:
-		if err := w.validateSolrVerticalScalingOpsRequest(req); err != nil {
+		warns, err := w.validateSolrVerticalScalingOpsRequest(req)
+		warnings = append(warnings, warns...)
+		if err != nil {
 			allErr = append(allErr, field.Invalid(field.NewPath("spec").Child("verticalScaling"),
 				req.Name,
 				err.Error()))
@@ -178,9 +182,9 @@ func (w *SolrOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.SolrOps
 	}
 
 	if len(allErr) == 0 {
-		return nil
+		return warnings, nil
 	}
-	return apierrors.NewInvalid(schema.GroupKind{Group: "solropsrequests.kubedb.com", Kind: "SolrOpsRequest"}, req.Name, allErr)
+	return warnings, apierrors.NewInvalid(schema.GroupKind{Group: "solropsrequests.kubedb.com", Kind: "SolrOpsRequest"}, req.Name, allErr)
 }
 
 func (w *SolrOpsRequestCustomWebhook) validateSolrStorageMigrationOpsRequest(req *opsapi.SolrOpsRequest, db *olddbapi.Solr) error {
@@ -262,20 +266,22 @@ func (w *SolrOpsRequestCustomWebhook) hasDatabaseRef(req *opsapi.SolrOpsRequest)
 	return db, nil
 }
 
-func (w *SolrOpsRequestCustomWebhook) validateSolrVerticalScalingOpsRequest(req *opsapi.SolrOpsRequest) error {
+func (w *SolrOpsRequestCustomWebhook) validateSolrVerticalScalingOpsRequest(req *opsapi.SolrOpsRequest) (admission.Warnings, error) {
 	verticalScalingSpec := req.Spec.VerticalScaling
 	if verticalScalingSpec == nil {
-		return errors.New("spec.verticalScaling nil not supported in VerticalScaling type")
+		return nil, errors.New("spec.verticalScaling nil not supported in VerticalScaling type")
 	}
 
 	if verticalScalingSpec.Node != nil && (verticalScalingSpec.Data != nil || verticalScalingSpec.Overseer != nil || verticalScalingSpec.Coordinator != nil) {
-		return errors.New("spec.verticalScaling.Node && spec.verticalScaling.Topology both can't be non-empty at the same ops request")
-	}
-	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
-		return errors.New("in-place vertical scaling is not supported for Solr: JVM heap is derived from container resources and requires a pod restart to take effect")
+		return nil, errors.New("spec.verticalScaling.Node && spec.verticalScaling.Topology both can't be non-empty at the same ops request")
 	}
 
-	return nil
+	var warnings admission.Warnings
+	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
+		warnings = append(warnings, "in-place vertical scaling is not recommended for Solr: JVM heap is derived from container resources and requires a pod restart to take effect")
+	}
+
+	return warnings, nil
 }
 
 func (w *SolrOpsRequestCustomWebhook) validateSolrHorizontalScalingOpsRequest(req *opsapi.SolrOpsRequest) error {

--- a/pkg/webhooks/ops/v1alpha1/solr.go
+++ b/pkg/webhooks/ops/v1alpha1/solr.go
@@ -271,6 +271,9 @@ func (w *SolrOpsRequestCustomWebhook) validateSolrVerticalScalingOpsRequest(req 
 	if verticalScalingSpec.Node != nil && (verticalScalingSpec.Data != nil || verticalScalingSpec.Overseer != nil || verticalScalingSpec.Coordinator != nil) {
 		return errors.New("spec.verticalScaling.Node && spec.verticalScaling.Topology both can't be non-empty at the same ops request")
 	}
+	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
+		return errors.New("in-place vertical scaling is not supported for Solr: JVM heap is derived from container resources and requires a pod restart to take effect")
+	}
 
 	return nil
 }

--- a/pkg/webhooks/ops/v1alpha1/zookeeper.go
+++ b/pkg/webhooks/ops/v1alpha1/zookeeper.go
@@ -188,6 +188,9 @@ func (z *ZooKeeperOpsRequestCustomWebhook) validateZooKeeperVerticalScalingOpsRe
 	if verticalScalingSpec.Node == nil {
 		return errors.New("spec.verticalScaling.Node can not be empty")
 	}
+	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
+		return errors.New("in-place vertical scaling is not supported for ZooKeeper: JVM heap is derived from container resources and requires a pod restart to take effect")
+	}
 
 	return nil
 }

--- a/pkg/webhooks/ops/v1alpha1/zookeeper.go
+++ b/pkg/webhooks/ops/v1alpha1/zookeeper.go
@@ -66,7 +66,7 @@ func (w *ZooKeeperOpsRequestCustomWebhook) ValidateCreate(ctx context.Context, o
 		return nil, fmt.Errorf("expected an ZooKeeperOpsRequest object but got %T", obj)
 	}
 	zookeeperLog.Info("validate create", "name", ops.Name)
-	return nil, w.validateCreateOrUpdate(ops)
+	return w.validateCreateOrUpdate(ops)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -86,18 +86,19 @@ func (w *ZooKeeperOpsRequestCustomWebhook) ValidateUpdate(ctx context.Context, o
 		return nil, err
 	}
 
-	if err := w.validateCreateOrUpdate(ops); err != nil {
-		return nil, err
+	warnings, err := w.validateCreateOrUpdate(ops)
+	if err != nil {
+		return warnings, err
 	}
 	if isOpsReqCompleted(ops.Status.Phase) && !isOpsReqCompleted(oldOps.Status.Phase) { // just completed
 		var db olddbapi.ZooKeeper
 		err := w.DefaultClient.Get(context.TODO(), types.NamespacedName{Name: ops.Spec.DatabaseRef.Name, Namespace: ops.Namespace}, &db)
 		if err != nil {
-			return nil, err
+			return warnings, err
 		}
-		return nil, resumeDatabase(w.DefaultClient, &db)
+		return warnings, resumeDatabase(w.DefaultClient, &db)
 	}
-	return nil, nil
+	return warnings, nil
 }
 
 func (w *ZooKeeperOpsRequestCustomWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
@@ -116,9 +117,9 @@ func validateZooKeeperOpsRequest(req *opsapi.ZooKeeperOpsRequest, oldReq *opsapi
 	return nil
 }
 
-func (z *ZooKeeperOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.ZooKeeperOpsRequest) error {
+func (z *ZooKeeperOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.ZooKeeperOpsRequest) (admission.Warnings, error) {
 	if validType, _ := arrays.Contains(opsapi.ZooKeeperOpsRequestTypeNames(), string(req.Spec.Type)); !validType {
-		return field.Invalid(field.NewPath("spec").Child("type"), req.Name,
+		return nil, field.Invalid(field.NewPath("spec").Child("type"), req.Name,
 			fmt.Sprintf("defined OpsRequestType %s is not supported, supported types for ZooKeeper are %s", req.Spec.Type, strings.Join(opsapi.ZooKeeperOpsRequestTypeNames(), ", ")))
 	}
 	var (
@@ -126,10 +127,11 @@ func (z *ZooKeeperOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.Zo
 		err       error
 	)
 	if zookeeper, err = z.hasDatabaseRef(req); err != nil {
-		return field.Invalid(field.NewPath("spec").Child("databaseRef"), req.Name, err.Error())
+		return nil, field.Invalid(field.NewPath("spec").Child("databaseRef"), req.Name, err.Error())
 	}
 
 	var allErr field.ErrorList
+	var warnings admission.Warnings
 	switch opsapi.ZooKeeperOpsRequestType(req.GetRequestType()) {
 	case opsapi.ZooKeeperOpsRequestTypeUpdateVersion:
 		if err := z.validateZooKeeperUpdateVersionOpsRequest(zookeeper, req); err != nil {
@@ -138,7 +140,9 @@ func (z *ZooKeeperOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.Zo
 				err.Error()))
 		}
 	case opsapi.ZooKeeperOpsRequestTypeVerticalScaling:
-		if err := z.validateZooKeeperVerticalScalingOpsRequest(req); err != nil {
+		warns, err := z.validateZooKeeperVerticalScalingOpsRequest(req)
+		warnings = append(warnings, warns...)
+		if err != nil {
 			allErr = append(allErr, field.Invalid(field.NewPath("spec").Child("type").Child("VerticalScaling"),
 				req.Name,
 				err.Error()))
@@ -164,9 +168,9 @@ func (z *ZooKeeperOpsRequestCustomWebhook) validateCreateOrUpdate(req *opsapi.Zo
 	}
 
 	if len(allErr) == 0 {
-		return nil
+		return warnings, nil
 	}
-	return apierrors.NewInvalid(schema.GroupKind{Group: "ZooKeeperopsrequests.kubedb.com", Kind: "ZooKeeperOpsRequest"}, req.Name, allErr)
+	return warnings, apierrors.NewInvalid(schema.GroupKind{Group: "ZooKeeperopsrequests.kubedb.com", Kind: "ZooKeeperOpsRequest"}, req.Name, allErr)
 }
 
 func (z *ZooKeeperOpsRequestCustomWebhook) hasDatabaseRef(req *opsapi.ZooKeeperOpsRequest) (*olddbapi.ZooKeeper, error) {
@@ -180,19 +184,21 @@ func (z *ZooKeeperOpsRequestCustomWebhook) hasDatabaseRef(req *opsapi.ZooKeeperO
 	return &zk, nil
 }
 
-func (z *ZooKeeperOpsRequestCustomWebhook) validateZooKeeperVerticalScalingOpsRequest(req *opsapi.ZooKeeperOpsRequest) error {
+func (z *ZooKeeperOpsRequestCustomWebhook) validateZooKeeperVerticalScalingOpsRequest(req *opsapi.ZooKeeperOpsRequest) (admission.Warnings, error) {
 	verticalScalingSpec := req.Spec.VerticalScaling
 	if verticalScalingSpec == nil {
-		return errors.New("spec.verticalScaling nil not supported in VerticalScaling type")
+		return nil, errors.New("spec.verticalScaling nil not supported in VerticalScaling type")
 	}
 	if verticalScalingSpec.Node == nil {
-		return errors.New("spec.verticalScaling.Node can not be empty")
-	}
-	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
-		return errors.New("in-place vertical scaling is not supported for ZooKeeper: JVM heap is derived from container resources and requires a pod restart to take effect")
+		return nil, errors.New("spec.verticalScaling.Node can not be empty")
 	}
 
-	return nil
+	var warnings admission.Warnings
+	if verticalScalingSpec.Mode == opsapi.VerticalScalingModeInPlace {
+		warnings = append(warnings, "in-place vertical scaling is not recommended for ZooKeeper: JVM heap is derived from container resources and requires a pod restart to take effect")
+	}
+
+	return warnings, nil
 }
 
 func (z *ZooKeeperOpsRequestCustomWebhook) validateZooKeeperUpdateVersionOpsRequest(db *olddbapi.ZooKeeper, req *opsapi.ZooKeeperOpsRequest) error {


### PR DESCRIPTION
Neo4j pins memory settings (`server.memory.heap.initial_size`, `server.memory.heap.max_size`, `server.memory.pagecache.size`) in `neo4j.conf`, which are only read at process startup. InPlace vertical scaling resizes the container via the `pods/resize` subresource without restarting the pod, so those settings would go stale after a resource change.

This adds a validator guard rejecting `VerticalScalingModeInPlace` for Neo4jOpsRequest.