### PR TITLE
Make MongoDB probes tolerate mongosh stdout warnings

### DIFF
--- a/apis/kubedb/v1/mongodb_helpers.go
+++ b/apis/kubedb/v1/mongodb_helpers.go
@@ -968,10 +968,15 @@ func (m *MongoDB) getCmdForProbes(mgVersion *v1alpha1.MongoDBVersion) []string {
 		}
 	}
 
+	// `tail -1` keeps only the evaluated value: mongosh writes startup warnings to
+	// stdout, so on images where $HOME is not writable by the pod's uid (e.g. mongos
+	// on mongodb-community-server, which has no /data/db volume) the substitution
+	// yields "Warning: ...\n1" and the arithmetic -eq aborts with a syntax error,
+	// failing the probe forever.
 	return []string{
 		"bash",
 		"-c",
-		fmt.Sprintf(`set -x; if [[ $(%s admin --host=localhost %v --quiet --eval "db.adminCommand('ping').ok" ) -eq "1" ]]; then 
+		fmt.Sprintf(`set -x; if [[ $(%s admin --host=localhost %v --quiet --eval "db.adminCommand('ping').ok" | tail -1) -eq "1" ]]; then
           exit 0
         fi
         exit 1`, m.GetEntryCommand(mgVersion), sslArgs),

--- a/apis/kubedb/v1alpha2/mongodb_helpers.go
+++ b/apis/kubedb/v1alpha2/mongodb_helpers.go
@@ -928,10 +928,15 @@ func (m *MongoDB) getCmdForProbes(mgVersion *v1alpha1.MongoDBVersion, isArbiter 
 	if len(isArbiter) == 0 { // not arbiter
 		authArgs = "--username=$MONGO_INITDB_ROOT_USERNAME --password=$MONGO_INITDB_ROOT_PASSWORD --authenticationDatabase=admin"
 	}
+	// `tail -1` keeps only the evaluated value: mongosh writes startup warnings to
+	// stdout, so on images where $HOME is not writable by the pod's uid (e.g. mongos
+	// on mongodb-community-server, which has no /data/db volume) the substitution
+	// yields "Warning: ...\n1" and the arithmetic -eq aborts with a syntax error,
+	// failing the probe forever.
 	return []string{
 		"bash",
 		"-c",
-		fmt.Sprintf(`set -x; if [[ $(%s admin --host=localhost %v %v --quiet --eval "db.adminCommand('ping').ok" ) -eq "1" ]]; then 
+		fmt.Sprintf(`set -x; if [[ $(%s admin --host=localhost %v %v --quiet --eval "db.adminCommand('ping').ok" | tail -1) -eq "1" ]]; then
           exit 0
         fi
         exit 1`, m.GetEntryCommand(mgVersion), sslArgs, authArgs),


### PR DESCRIPTION
## Problem

`getCmdForProbes` compares the whole command substitution using the arithmetic `-eq`:

```bash
set -x; if [[ $(mongosh admin --host=localhost --quiet --eval "db.adminCommand('ping').ok" ) -eq "1" ]]; then
```

mongosh writes startup warnings to **stdout**, not stderr. On an image where `$HOME` is not writable by the pod's uid, the substitution becomes:

```
Warning: Could not access file: EACCES: permission denied, mkdir '/data/db/.mongodb'
1
```

and bash aborts the comparison:

```
bash: line 1: [[: Warning: Could not access file: EACCES: permission denied, mkdir '/data/db/.mongodb'
1: syntax error in expression (error token is ": Could not access file: ...")
+ exit 1
```

The probe then fails permanently, regardless of whether the server is healthy.

## Impact

Reproduced on `mongodb/mongodb-community-server:8.0.26-ubi9-slim`. That image sets `HOME=/data/db`, owned by `mongod`, while the pod runs as uid 999. Shard and config-server pods are fine because `/data/db` is a PVC with `fsGroup: 999`, but **mongos has no `/data/db` volume**, so `$HOME` is read-only there.

Result: liveness kills mongos roughly every 40s, `sh.addShard` never lands, and the MongoDB stays in `Provisioning`. The only workaround today is a per-database `HOME` override in the CR, which makes the yaml differ by db version:

```yaml
containers:
- name: mongodb
  env:
  - name: HOME
    value: /work-dir
```

## Fix

Pipe through `tail -1` so only the evaluated value reaches the comparison. Applied to both `v1` and `v1alpha2`, which carry the identical string.

## Verification

`go build ./...` and `gofmt` clean. Bash semantics checked on each case — only the broken one changes:

| mongosh stdout | before | after |
|---|---|---|
| `Warning: …EACCES…` + `1` | unhealthy (syntax error) | **healthy** |
| `1` | healthy | healthy |
| empty (server down) | unhealthy | unhealthy |
| `0` | unhealthy | unhealthy |

## Related

Companion init-script fix in kubedb/mongodb-init-docker#39 — the same image also ships no `jq`/`grep`/`awk`/`sed`, which was silently breaking replica-set bootstrap.
