### PR TITLE
Skip db webhook defaulting/validation when deletionTimestamp is set

### DIFF
--- a/pkg/webhooks/kubedb/v1/elasticsearch.go
+++ b/pkg/webhooks/kubedb/v1/elasticsearch.go
@@ -64,6 +64,9 @@ var eslog = logf.Log.WithName("elasticsearch-resource")
 var _ webhook.CustomDefaulter = &ElasticsearchCustomWebhook{}
 
 func (w *ElasticsearchCustomWebhook) Default(_ context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db := obj.(*dbapi.Elasticsearch)
 	if db.Spec.Version == "" {
 		return errors.New(`'spec.version' is missing`)
@@ -310,6 +313,9 @@ func (w *ElasticsearchCustomWebhook) ValidateElasticsearch(db *dbapi.Elasticsear
 }
 
 func (w *ElasticsearchCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	es := obj.(*dbapi.Elasticsearch)
 	err := w.ValidateElasticsearch(es)
 	mysqlLog.Info("validating", "name", es.Name)
@@ -317,6 +323,9 @@ func (w *ElasticsearchCustomWebhook) ValidateCreate(ctx context.Context, obj run
 }
 
 func (w *ElasticsearchCustomWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	oldElasticsearch, ok := oldObj.(*dbapi.Elasticsearch)
 	if !ok {
 		return nil, fmt.Errorf("expected a Elasticsearch but got a %T", oldElasticsearch)

--- a/pkg/webhooks/kubedb/v1/helpers.go
+++ b/pkg/webhooks/kubedb/v1/helpers.go
@@ -1,0 +1,32 @@
+/*
+Copyright AppsCode Inc. and Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Defaulting & validation must be skipped once the object is being deleted,
+// otherwise updates like finalizer removal get rejected.
+func isDeletionInProgress(obj runtime.Object) bool {
+	acc, err := meta.Accessor(obj)
+	if err != nil {
+		return false
+	}
+	return acc.GetDeletionTimestamp() != nil
+}

--- a/pkg/webhooks/kubedb/v1/kafka.go
+++ b/pkg/webhooks/kubedb/v1/kafka.go
@@ -62,6 +62,9 @@ var _ webhook.CustomDefaulter = &KafkaCustomWebhook{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *KafkaCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*dbapi.Kafka)
 	if !ok {
 		return fmt.Errorf("expected an Kafka object but got %T", obj)
@@ -76,6 +79,9 @@ var _ webhook.CustomValidator = &KafkaCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *KafkaCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*dbapi.Kafka)
 	if !ok {
 		return nil, fmt.Errorf("expected an Kafka object but got %T", obj)
@@ -86,6 +92,9 @@ func (w *KafkaCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Obj
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *KafkaCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*dbapi.Kafka)
 	if !ok {
 		return nil, fmt.Errorf("expected an Kafka object but got %T", newObj)

--- a/pkg/webhooks/kubedb/v1/mariadb.go
+++ b/pkg/webhooks/kubedb/v1/mariadb.go
@@ -67,6 +67,9 @@ var mariadbLog = logf.Log.WithName("mariadb-resource")
 
 // setDefaultValues provides the defaulting that is performed in mutating stage of creating/updating a MySQL database
 func (w *MariaDBCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db := obj.(*dbapi.MariaDB)
 	mariadbLog.Info("defaulting", "name", db.GetName())
 	if db.Spec.Version == "" {
@@ -136,6 +139,9 @@ func (w *MariaDBCustomWebhook) Default(ctx context.Context, obj runtime.Object) 
 var _ webhook.CustomValidator = &MariaDBCustomWebhook{}
 
 func (w MariaDBCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	mariadb := obj.(*dbapi.MariaDB)
 	mariadbLog.Info("validating", "name", mariadb.Name)
 
@@ -143,6 +149,9 @@ func (w MariaDBCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Ob
 }
 
 func (w MariaDBCustomWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	oldMariaDB, ok := oldObj.(*dbapi.MariaDB)
 	if !ok {
 		return nil, fmt.Errorf("expected a MariaDB but got a %T", oldMariaDB)

--- a/pkg/webhooks/kubedb/v1/memcached.go
+++ b/pkg/webhooks/kubedb/v1/memcached.go
@@ -78,6 +78,9 @@ var _ webhook.CustomDefaulter = &MemcachedCustomWebhook{}
 var memLog = logf.Log.WithName("memcached-resource")
 
 func (mv *MemcachedCustomWebhook) Default(_ context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*dbapi.Memcached)
 	if !ok {
 		return fmt.Errorf("expected a Memcached but got a %T", obj)
@@ -281,12 +284,18 @@ func (mv MemcachedCustomWebhook) validate(ctx context.Context, obj runtime.Objec
 }
 
 func (mv MemcachedCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	memcached := obj.(*dbapi.Memcached)
 	memLog.Info("validating", "name", memcached.Name)
 	return mv.validate(ctx, obj)
 }
 
 func (mv MemcachedCustomWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	oldMemcached, ok := oldObj.(*dbapi.Memcached)
 	if !ok {
 		return nil, fmt.Errorf("expected a Memcached but got a %T", oldObj)

--- a/pkg/webhooks/kubedb/v1/mongodb.go
+++ b/pkg/webhooks/kubedb/v1/mongodb.go
@@ -64,6 +64,9 @@ type MongoDBCustomWebhook struct {
 var _ webhook.CustomDefaulter = &MongoDBCustomWebhook{}
 
 func (w MongoDBCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	log := logf.FromContext(ctx)
 	log.Info("defaulting MongoDB")
 	db := obj.(*dbapi.MongoDB)
@@ -95,12 +98,18 @@ func (w MongoDBCustomWebhook) Default(ctx context.Context, obj runtime.Object) e
 var _ webhook.CustomValidator = &MongoDBCustomWebhook{}
 
 func (w MongoDBCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	log := logf.FromContext(ctx)
 	log.Info("creating MongoDB")
 	return nil, w.ValidateMongoDB(obj.(*dbapi.MongoDB))
 }
 
 func (w MongoDBCustomWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	log := logf.FromContext(ctx)
 	log.Info("updating MongoDB")
 	oldMongoDB, ok := oldObj.(*dbapi.MongoDB)

--- a/pkg/webhooks/kubedb/v1/mysql.go
+++ b/pkg/webhooks/kubedb/v1/mysql.go
@@ -62,6 +62,9 @@ var mysqlLog = logf.Log.WithName("mysql-resource")
 var _ webhook.CustomDefaulter = &MySQLCustomWebhook{}
 
 func (w MySQLCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db := obj.(*dbapi.MySQL)
 	mysqlLog.Info("defaulting", "name", db.GetName())
 
@@ -94,6 +97,9 @@ func (w MySQLCustomWebhook) Default(ctx context.Context, obj runtime.Object) err
 var _ webhook.CustomValidator = &MySQLCustomWebhook{}
 
 func (w MySQLCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	mysql := obj.(*dbapi.MySQL)
 	err = w.ValidateMySQL(mysql)
 	mysqlLog.Info("validating", "name", mysql.Name)
@@ -101,6 +107,9 @@ func (w MySQLCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Obje
 }
 
 func (w MySQLCustomWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	oldMySQL, ok := oldObj.(*dbapi.MySQL)
 	if !ok {
 		return nil, fmt.Errorf("expected a MySQL but got a %T", oldMySQL)

--- a/pkg/webhooks/kubedb/v1/perconaxtradb.go
+++ b/pkg/webhooks/kubedb/v1/perconaxtradb.go
@@ -59,6 +59,9 @@ var pxlLog = logf.Log.WithName("perconaxtradb-resource")
 var _ webhook.CustomDefaulter = &PerconaXtraDBCustomWebhook{}
 
 func (w PerconaXtraDBCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db := obj.(*dbapi.PerconaXtraDB)
 	pxlLog.Info("defaulting", "name", db.GetName())
 	if db.Spec.Version == "" {
@@ -87,6 +90,9 @@ func (w PerconaXtraDBCustomWebhook) Default(ctx context.Context, obj runtime.Obj
 var _ webhook.CustomValidator = &PerconaXtraDBCustomWebhook{}
 
 func (w PerconaXtraDBCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	perconaxtradb := obj.(*dbapi.PerconaXtraDB)
 	err = w.ValidatePerconaXtraDB(perconaxtradb)
 	pxlLog.Info("validating", "name", perconaxtradb.GetName())
@@ -94,6 +100,9 @@ func (w PerconaXtraDBCustomWebhook) ValidateCreate(ctx context.Context, obj runt
 }
 
 func (w PerconaXtraDBCustomWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	oldPerconaXtraDB, ok := oldObj.(*dbapi.PerconaXtraDB)
 	if !ok {
 		return nil, fmt.Errorf("expected a PerconaXtraDB but got a %T", oldPerconaXtraDB)

--- a/pkg/webhooks/kubedb/v1/pgbouncer.go
+++ b/pkg/webhooks/kubedb/v1/pgbouncer.go
@@ -62,6 +62,9 @@ var _ webhook.CustomDefaulter = &PgBouncerCustomWebhook{}
 var pgBouncerLog = logf.Log.WithName("pqbouncer-resource")
 
 func (pw PgBouncerCustomWebhook) Default(_ context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*dbapi.PgBouncer)
 	if !ok {
 		return fmt.Errorf("expected an PgBouncer object but got %T", obj)
@@ -118,6 +121,9 @@ var pbReservedMountPaths = []string{
 }
 
 func (pw PgBouncerCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	pgBouncer, ok := obj.(*dbapi.PgBouncer)
 	if !ok {
 		return nil, fmt.Errorf("expected a PgBouncer but got a %T", pgBouncer)
@@ -132,6 +138,9 @@ func (pw PgBouncerCustomWebhook) ValidateCreate(ctx context.Context, obj runtime
 }
 
 func (pw PgBouncerCustomWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	// TODO : user can't update anything related to config
 	pgBouncer, ok := newObj.(*dbapi.PgBouncer)
 	if !ok {

--- a/pkg/webhooks/kubedb/v1/postgres.go
+++ b/pkg/webhooks/kubedb/v1/postgres.go
@@ -64,6 +64,9 @@ var pgLog = logf.Log.WithName("postgres-resource")
 var _ webhook.CustomDefaulter = &PostgresCustomWebhook{}
 
 func (wh *PostgresCustomWebhook) Default(_ context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db := obj.(*dbapi.Postgres)
 
 	pgLog.Info("defaulting", "name", db.GetName())
@@ -576,6 +579,9 @@ func (wh *PostgresCustomWebhook) validate(postgres *dbapi.Postgres) (admission.W
 }
 
 func (wh *PostgresCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	postgres, ok := obj.(*dbapi.Postgres)
 	if !ok {
 		return nil, fmt.Errorf("expected a Postgres but got a %T", obj)
@@ -586,6 +592,9 @@ func (wh *PostgresCustomWebhook) ValidateCreate(ctx context.Context, obj runtime
 }
 
 func (wh *PostgresCustomWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	oldPostgres, ok := oldObj.(*dbapi.Postgres)
 	if !ok {
 		return nil, fmt.Errorf("expected a Postgres but got a %T", oldPostgres)

--- a/pkg/webhooks/kubedb/v1/proxysql.go
+++ b/pkg/webhooks/kubedb/v1/proxysql.go
@@ -56,6 +56,9 @@ type ProxySQLCustomWebhook struct {
 var _ webhook.CustomDefaulter = &ProxySQLCustomWebhook{}
 
 func (w ProxySQLCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db := obj.(*dbapi.ProxySQL)
 	proxyLog.Info("defaulting", "name", db.GetName())
 	if db.Spec.Version == "" {
@@ -85,6 +88,9 @@ func (w ProxySQLCustomWebhook) Default(ctx context.Context, obj runtime.Object) 
 var _ webhook.CustomValidator = &ProxySQLCustomWebhook{}
 
 func (w ProxySQLCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	proxysql := obj.(*dbapi.ProxySQL)
 	proxyLog.Info("validating", "name", proxysql.Name)
 	err = w.ValidateProxySQL(proxysql)
@@ -92,6 +98,9 @@ func (w ProxySQLCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.O
 }
 
 func (w ProxySQLCustomWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	oldProxy, ok := oldObj.(*dbapi.ProxySQL)
 	if !ok {
 		return nil, fmt.Errorf("expected a Postgres but got a %T", oldProxy)

--- a/pkg/webhooks/kubedb/v1/redis.go
+++ b/pkg/webhooks/kubedb/v1/redis.go
@@ -62,6 +62,9 @@ var _ webhook.CustomDefaulter = &RedisCustomWebhook{}
 var redisLog = logf.Log.WithName("redis-resource")
 
 func (w RedisCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	redis, ok := obj.(*dbapi.Redis)
 	if !ok {
 		return fmt.Errorf("expected a Redis but got a %T", obj)
@@ -94,6 +97,9 @@ func (w RedisCustomWebhook) Default(ctx context.Context, obj runtime.Object) err
 var _ webhook.CustomValidator = &RedisCustomWebhook{}
 
 func (w RedisCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	redis, ok := obj.(*dbapi.Redis)
 	if !ok {
 		return nil, fmt.Errorf("expected a Redis but got a %T", obj)
@@ -104,6 +110,9 @@ func (w RedisCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Obje
 }
 
 func (w RedisCustomWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	oldRedis, ok := oldObj.(*dbapi.Redis)
 	if !ok {
 		return nil, fmt.Errorf("expected a Redis but got a %T", oldRedis)

--- a/pkg/webhooks/kubedb/v1/redissentinel.go
+++ b/pkg/webhooks/kubedb/v1/redissentinel.go
@@ -60,6 +60,9 @@ var _ webhook.CustomDefaulter = &RedisSentinelCustomWebhook{}
 var sentinelLog = logf.Log.WithName("redissentinel-resource")
 
 func (w RedisSentinelCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	sentinel, ok := obj.(*dbapi.RedisSentinel)
 	if !ok {
 		return fmt.Errorf("expected a RedisSentinel but got a %T", obj)
@@ -92,6 +95,9 @@ func (w RedisSentinelCustomWebhook) Default(ctx context.Context, obj runtime.Obj
 var _ webhook.CustomValidator = &RedisSentinelCustomWebhook{}
 
 func (w RedisSentinelCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	sentinel, ok := obj.(*dbapi.RedisSentinel)
 	if !ok {
 		return nil, fmt.Errorf("expected a RedisSentinel but got a %T", obj)
@@ -102,6 +108,9 @@ func (w RedisSentinelCustomWebhook) ValidateCreate(ctx context.Context, obj runt
 }
 
 func (w RedisSentinelCustomWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	oldRedisSentinel, ok := oldObj.(*dbapi.RedisSentinel)
 	if !ok {
 		return nil, fmt.Errorf("expected a RedisSentinel but got a %T", oldRedisSentinel)

--- a/pkg/webhooks/kubedb/v1alpha2/aerospike.go
+++ b/pkg/webhooks/kubedb/v1alpha2/aerospike.go
@@ -57,6 +57,9 @@ var _ webhook.CustomDefaulter = &AerospikeCustomWebhook{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *AerospikeCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	ar, ok := obj.(*olddbapi.Aerospike)
 	if !ok {
 		return fmt.Errorf("expected an aerospike object but got %T", obj)
@@ -72,6 +75,9 @@ var _ webhook.CustomValidator = &AerospikeCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *AerospikeCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	ar, ok := obj.(*olddbapi.Aerospike)
 	if !ok {
 		return nil, fmt.Errorf("expected an aerospike object but got %T", obj)
@@ -82,6 +88,9 @@ func (w *AerospikeCustomWebhook) ValidateCreate(ctx context.Context, obj runtime
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *AerospikeCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	ar, ok := newObj.(*olddbapi.Aerospike)
 	if !ok {
 		return nil, fmt.Errorf("expected an aerospike object but got %T", ar)

--- a/pkg/webhooks/kubedb/v1alpha2/cassandra.go
+++ b/pkg/webhooks/kubedb/v1alpha2/cassandra.go
@@ -64,6 +64,9 @@ var cassandralog = logf.Log.WithName("cassandra-resource")
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *CassandraCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.Cassandra)
 	if !ok {
 		return fmt.Errorf("expected an Cassandra object but got %T", obj)
@@ -77,6 +80,9 @@ var _ webhook.CustomValidator = &CassandraCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *CassandraCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.Cassandra)
 	if !ok {
 		return nil, fmt.Errorf("expected an Cassandra object but got %T", obj)
@@ -87,6 +93,9 @@ func (w *CassandraCustomWebhook) ValidateCreate(ctx context.Context, obj runtime
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *CassandraCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.Cassandra)
 	if !ok {
 		return nil, fmt.Errorf("expected an Cassandra object but got %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/clickhouse.go
+++ b/pkg/webhooks/kubedb/v1alpha2/clickhouse.go
@@ -60,6 +60,9 @@ var clickhouselog = logf.Log.WithName("clickhouse-resource")
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *ClickHouseCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.ClickHouse)
 	if !ok {
 		return fmt.Errorf("expected an ClickHouse object but got %T", obj)
@@ -73,6 +76,9 @@ var _ webhook.CustomValidator = &ClickHouseCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *ClickHouseCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.ClickHouse)
 	if !ok {
 		return nil, fmt.Errorf("expected an ClickHouse object but got %T", obj)
@@ -83,6 +89,9 @@ func (w *ClickHouseCustomWebhook) ValidateCreate(ctx context.Context, obj runtim
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *ClickHouseCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.ClickHouse)
 	if !ok {
 		return nil, fmt.Errorf("expected an ClickHouse object but got %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/db2.go
+++ b/pkg/webhooks/kubedb/v1alpha2/db2.go
@@ -60,6 +60,9 @@ var db2log = logf.Log.WithName("DB2-resource")
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *DB2CustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.DB2)
 	if !ok {
 		return fmt.Errorf("expected an DB2 object but got %T", obj)
@@ -75,6 +78,9 @@ var _ webhook.CustomValidator = &DB2CustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *DB2CustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.DB2)
 	if !ok {
 		return nil, fmt.Errorf("expected an DB2 object but got %T", obj)
@@ -89,6 +95,9 @@ func (w *DB2CustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Objec
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *DB2CustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.DB2)
 	if !ok {
 		return nil, fmt.Errorf("expected an DB2 object but got %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/documentdb.go
+++ b/pkg/webhooks/kubedb/v1alpha2/documentdb.go
@@ -79,6 +79,9 @@ var _ webhook.CustomDefaulter = &DocumentDBCustomWebhook{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *DocumentDBCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.DocumentDB)
 	if !ok {
 		return fmt.Errorf("expected an DocumentDB object but got %T", obj)
@@ -108,6 +111,9 @@ var _ webhook.CustomValidator = &DocumentDBCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *DocumentDBCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.DocumentDB)
 	if !ok {
 		return nil, fmt.Errorf("expected an DocumentDB object but got %T", obj)
@@ -123,6 +129,9 @@ func (w *DocumentDBCustomWebhook) ValidateCreate(ctx context.Context, obj runtim
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *DocumentDBCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.DocumentDB)
 	if !ok {
 		return nil, fmt.Errorf("expected an DocumentDB object but got %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/druid.go
+++ b/pkg/webhooks/kubedb/v1alpha2/druid.go
@@ -60,6 +60,9 @@ var druidlog = logf.Log.WithName("druid-resource")
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *DruidCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.Druid)
 	if !ok {
 		return fmt.Errorf("expected an Druid object but got %T", obj)
@@ -77,6 +80,9 @@ var _ webhook.CustomValidator = &DruidCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *DruidCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.Druid)
 	if !ok {
 		return nil, fmt.Errorf("expected an Druid object but got %T", obj)
@@ -91,6 +97,9 @@ func (w *DruidCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Obj
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *DruidCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.Druid)
 	if !ok {
 		return nil, fmt.Errorf("expected an Druid object but got %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/hanadb.go
+++ b/pkg/webhooks/kubedb/v1alpha2/hanadb.go
@@ -64,6 +64,9 @@ var hanaLog = logf.Log.WithName("hanadb-resource")
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *HanaDBCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*api.HanaDB)
 	if !ok {
 		return fmt.Errorf("expected a HanaDB object, got a %T", obj)
@@ -79,6 +82,9 @@ var _ webhook.CustomValidator = &HanaDBCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *HanaDBCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*api.HanaDB)
 	if !ok {
 		return nil, fmt.Errorf("expected a HanaDB object, got a %T", obj)
@@ -95,6 +101,9 @@ func (w *HanaDBCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Ob
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *HanaDBCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*api.HanaDB)
 	if !ok {
 		return nil, fmt.Errorf("expected a HanaDB object, got a %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/hazelcast.go
+++ b/pkg/webhooks/kubedb/v1alpha2/hazelcast.go
@@ -59,6 +59,9 @@ type HazelcastCustomWebhook struct {
 var _ webhook.CustomDefaulter = &HazelcastCustomWebhook{}
 
 func (w *HazelcastCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.Hazelcast)
 	if !ok {
 		return fmt.Errorf("expected an Hazelcast object but got %T", obj)
@@ -86,6 +89,9 @@ var hazelcastReservedVolumeMountPaths = []string{
 var _ webhook.CustomValidator = &HazelcastCustomWebhook{}
 
 func (w *HazelcastCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.Hazelcast)
 	if !ok {
 		return nil, fmt.Errorf("expected an Hazelcast object but got %T", obj)
@@ -211,6 +217,9 @@ func (w *HazelcastCustomWebhook) hazelcastValidateVolumesMountPaths(podTemplate 
 }
 
 func (w *HazelcastCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.Hazelcast)
 	if !ok {
 		return nil, fmt.Errorf("expected an Hazelcast object but got %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/helpers.go
+++ b/pkg/webhooks/kubedb/v1alpha2/helpers.go
@@ -1,0 +1,32 @@
+/*
+Copyright AppsCode Inc. and Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Defaulting & validation must be skipped once the object is being deleted,
+// otherwise updates like finalizer removal get rejected.
+func isDeletionInProgress(obj runtime.Object) bool {
+	acc, err := meta.Accessor(obj)
+	if err != nil {
+		return false
+	}
+	return acc.GetDeletionTimestamp() != nil
+}

--- a/pkg/webhooks/kubedb/v1alpha2/ignite.go
+++ b/pkg/webhooks/kubedb/v1alpha2/ignite.go
@@ -60,6 +60,9 @@ var Ignitelog = logf.Log.WithName("Ignite-resource")
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *IgniteCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.Ignite)
 	if !ok {
 		return fmt.Errorf("expected an Ignite object but got %T", obj)
@@ -76,6 +79,9 @@ var _ webhook.CustomValidator = &IgniteCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *IgniteCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.Ignite)
 	if !ok {
 		return nil, fmt.Errorf("expected an Ignite object but got %T", obj)
@@ -86,6 +92,9 @@ func (w *IgniteCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Ob
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *IgniteCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.Ignite)
 	if !ok {
 		return nil, fmt.Errorf("expected an Ignite object but got %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/kafka.go
+++ b/pkg/webhooks/kubedb/v1alpha2/kafka.go
@@ -59,6 +59,9 @@ var _ webhook.CustomDefaulter = &KafkaCustomWebhook{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *KafkaCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.Kafka)
 	if !ok {
 		return fmt.Errorf("expected an Kafka object but got %T", obj)
@@ -73,6 +76,9 @@ var _ webhook.CustomValidator = &KafkaCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *KafkaCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.Kafka)
 	if !ok {
 		return nil, fmt.Errorf("expected an Kafka object but got %T", obj)
@@ -83,6 +89,9 @@ func (w *KafkaCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Obj
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *KafkaCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.Kafka)
 	if !ok {
 		return nil, fmt.Errorf("expected an Kafka object but got %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/milvus.go
+++ b/pkg/webhooks/kubedb/v1alpha2/milvus.go
@@ -63,6 +63,9 @@ var milvuslog = logf.Log.WithName("milvus-resource")
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (m *MilvusCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.Milvus)
 	if !ok {
 		return fmt.Errorf("expected a Milvus object, got a %T", obj)
@@ -78,6 +81,9 @@ var _ webhook.CustomValidator = &MilvusCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (m *MilvusCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.Milvus)
 	if !ok {
 		return nil, fmt.Errorf("expected a Milvus object, got a %T", obj)
@@ -94,6 +100,9 @@ func (m *MilvusCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Ob
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (m *MilvusCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.Milvus)
 	if !ok {
 		return nil, fmt.Errorf("expected a Milvus object, got a %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/mssqlserver.go
+++ b/pkg/webhooks/kubedb/v1alpha2/mssqlserver.go
@@ -66,6 +66,9 @@ var mssqllog = logf.Log.WithName("mssql-resource")
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *MSSQLServerCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.MSSQLServer)
 	if !ok {
 		return fmt.Errorf("expected a MSSQLServer object, got a %T", obj)
@@ -81,6 +84,9 @@ var _ webhook.CustomValidator = &MSSQLServerCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *MSSQLServerCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.MSSQLServer)
 	if !ok {
 		return nil, fmt.Errorf("expected a MSSQLServer object, got a %T", obj)
@@ -97,6 +103,9 @@ func (w *MSSQLServerCustomWebhook) ValidateCreate(ctx context.Context, obj runti
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *MSSQLServerCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.MSSQLServer)
 	if !ok {
 		return nil, fmt.Errorf("expected a MSSQLServer object, got a %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/neo4j.go
+++ b/pkg/webhooks/kubedb/v1alpha2/neo4j.go
@@ -65,6 +65,9 @@ var Neo4jlog = logf.Log.WithName("Neo4j-resource")
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *Neo4jCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.Neo4j)
 	if !ok {
 		return fmt.Errorf("expected an Neo4j object but got %T", obj)
@@ -81,6 +84,9 @@ var _ webhook.CustomValidator = &Neo4jCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *Neo4jCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.Neo4j)
 	if !ok {
 		return nil, fmt.Errorf("expected an Neo4j object but got %T", obj)
@@ -91,6 +97,9 @@ func (w *Neo4jCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Obj
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *Neo4jCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.Neo4j)
 	if !ok {
 		return nil, fmt.Errorf("expected an Neo4j object but got %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/oracle.go
+++ b/pkg/webhooks/kubedb/v1alpha2/oracle.go
@@ -67,6 +67,9 @@ var oraLog = logf.Log.WithName("oracle-resource")
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *OracleCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.Oracle)
 	if !ok {
 		return fmt.Errorf("expected a Oracle object, got a %T", obj)
@@ -82,6 +85,9 @@ var _ webhook.CustomValidator = &OracleCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *OracleCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.Oracle)
 	if !ok {
 		return nil, fmt.Errorf("expected a Oracle object, got a %T", obj)
@@ -98,6 +104,9 @@ func (w *OracleCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Ob
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *OracleCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.Oracle)
 	if !ok {
 		return nil, fmt.Errorf("expected a Oracle object, got a %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/pgpool.go
+++ b/pkg/webhooks/kubedb/v1alpha2/pgpool.go
@@ -68,6 +68,9 @@ var _ webhook.CustomDefaulter = &PgpoolCustomWebhook{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *PgpoolCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	pp, ok := obj.(*olddbapi.Pgpool)
 	if !ok {
 		return fmt.Errorf("expected an pgpool object but got %T", obj)
@@ -84,6 +87,9 @@ var _ webhook.CustomValidator = &PgpoolCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *PgpoolCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	pp, ok := obj.(*olddbapi.Pgpool)
 	if !ok {
 		return nil, fmt.Errorf("expected an pgpool object but got %T", obj)
@@ -98,6 +104,9 @@ func (w *PgpoolCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Ob
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *PgpoolCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	pp, ok := newObj.(*olddbapi.Pgpool)
 	if !ok {
 		return nil, fmt.Errorf("expected an pgpool object but got %T", pp)

--- a/pkg/webhooks/kubedb/v1alpha2/qdrant.go
+++ b/pkg/webhooks/kubedb/v1alpha2/qdrant.go
@@ -60,6 +60,9 @@ var qdrantlog = logf.Log.WithName("qdrant-resource")
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *QdrantCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.Qdrant)
 	if !ok {
 		return fmt.Errorf("expected a Qdrant object, got a %T", obj)
@@ -75,6 +78,9 @@ var _ webhook.CustomValidator = &QdrantCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *QdrantCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.Qdrant)
 	if !ok {
 		return nil, fmt.Errorf("expected a Qdrant object, got a %T", obj)
@@ -91,6 +97,9 @@ func (w *QdrantCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Ob
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *QdrantCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.Qdrant)
 	if !ok {
 		return nil, fmt.Errorf("expected a Qdrant object, got a %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/rabbitmq.go
+++ b/pkg/webhooks/kubedb/v1alpha2/rabbitmq.go
@@ -60,6 +60,9 @@ var rabbitmqlog = logf.Log.WithName("rabbitmq-resource")
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *RabbitMQCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.RabbitMQ)
 	if !ok {
 		return fmt.Errorf("expected an RabbitMQ object but got %T", obj)
@@ -76,6 +79,9 @@ var _ webhook.CustomValidator = &RabbitMQCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *RabbitMQCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.RabbitMQ)
 	if !ok {
 		return nil, fmt.Errorf("expected an RabbitMQ object but got %T", obj)
@@ -86,6 +92,9 @@ func (w *RabbitMQCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *RabbitMQCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.RabbitMQ)
 	if !ok {
 		return nil, fmt.Errorf("expected an RabbitMQ object but got %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/singlestore.go
+++ b/pkg/webhooks/kubedb/v1alpha2/singlestore.go
@@ -60,6 +60,9 @@ var singlestorelog = logf.Log.WithName("singlestore-resource")
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *SinglestoreCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.Singlestore)
 	if !ok {
 		return fmt.Errorf("expected an Singlestore object but got %T", obj)
@@ -75,6 +78,9 @@ var _ webhook.CustomValidator = &SinglestoreCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *SinglestoreCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.Singlestore)
 	if !ok {
 		return nil, fmt.Errorf("expected an Singlestore object but got %T", obj)
@@ -90,6 +96,9 @@ func (w *SinglestoreCustomWebhook) ValidateCreate(ctx context.Context, obj runti
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *SinglestoreCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.Singlestore)
 	if !ok {
 		return nil, fmt.Errorf("expected an Singlestore object but got %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/solr.go
+++ b/pkg/webhooks/kubedb/v1alpha2/solr.go
@@ -63,6 +63,9 @@ var solrlog = logf.Log.WithName("solr-resource")
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *SolrCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.Solr)
 	if !ok {
 		return fmt.Errorf("expected an Solr object but got %T", obj)
@@ -78,6 +81,9 @@ var _ webhook.CustomValidator = &SolrCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *SolrCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.Solr)
 	if !ok {
 		return nil, fmt.Errorf("expected an Solr object but got %T", obj)
@@ -93,6 +99,9 @@ func (w *SolrCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Obje
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *SolrCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.Solr)
 	if !ok {
 		return nil, fmt.Errorf("expected an Solr object but got %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/weaviate.go
+++ b/pkg/webhooks/kubedb/v1alpha2/weaviate.go
@@ -57,6 +57,9 @@ var weaviatelog = logf.Log.WithName("weaviate-resource")
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *WeaviateCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.Weaviate)
 	if !ok {
 		return fmt.Errorf("expected an Weaviate object but got %T", obj)
@@ -71,6 +74,9 @@ var _ webhook.CustomValidator = &WeaviateCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *WeaviateCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.Weaviate)
 	if !ok {
 		return nil, fmt.Errorf("expected an Weaviate object but got %T", obj)
@@ -81,6 +87,9 @@ func (w *WeaviateCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *WeaviateCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.Weaviate)
 	if !ok {
 		return nil, fmt.Errorf("expected an Weaviate object but got %T", newObj)

--- a/pkg/webhooks/kubedb/v1alpha2/zookeeper.go
+++ b/pkg/webhooks/kubedb/v1alpha2/zookeeper.go
@@ -61,6 +61,9 @@ var _ webhook.CustomDefaulter = &ZooKeeperCustomWebhook{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (w *ZooKeeperCustomWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	if isDeletionInProgress(obj) {
+		return nil
+	}
 	db, ok := obj.(*olddbapi.ZooKeeper)
 	if !ok {
 		return fmt.Errorf("expected an ZooKeeper object but got %T", obj)
@@ -76,6 +79,9 @@ var _ webhook.CustomValidator = &ZooKeeperCustomWebhook{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (w *ZooKeeperCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(obj) {
+		return nil, nil
+	}
 	db, ok := obj.(*olddbapi.ZooKeeper)
 	if !ok {
 		return nil, fmt.Errorf("expected an ZooKeeper object but got %T", obj)
@@ -86,6 +92,9 @@ func (w *ZooKeeperCustomWebhook) ValidateCreate(ctx context.Context, obj runtime
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (w *ZooKeeperCustomWebhook) ValidateUpdate(ctx context.Context, old, newObj runtime.Object) (admission.Warnings, error) {
+	if isDeletionInProgress(newObj) {
+		return nil, nil
+	}
 	db, ok := newObj.(*olddbapi.ZooKeeper)
 	if !ok {
 		return nil, fmt.Errorf("expected an ZooKeeper object but got %T", newObj)


### PR DESCRIPTION
Once a DB object has `metadata.deletionTimestamp` set, `Default`, `ValidateCreate` and `ValidateUpdate` now return immediately in all `pkg/webhooks/kubedb/{v1,v1alpha2}` webhooks. Otherwise updates such as finalizer removal can be rejected by the webhook.

`ValidateDelete` is untouched — that is where `spec.deletionPolicy: DoNotTerminate` is enforced.

Follows the existing pattern in `pkg/webhooks/elasticsearch/v1alpha1/elasticsearchdashboard.go`. The check is a small per-package `isDeletionInProgress()` helper using `meta.Accessor`, applied to 33 db webhook files.