### PR TITLE
Harden generated auth-secret passwords: crypto/rand + optional per-DB generator

### DIFF
--- a/pkg/controller/secret/auth_secret.go
+++ b/pkg/controller/secret/auth_secret.go
@@ -55,6 +55,19 @@ type Options struct {
 	// DefaultUsername is rejected; when false, only the presence of the
 	// username/password keys is checked.
 	EnforceUsername bool
+	// PasswordGenerator overrides how the password of a kubedb-generated auth
+	// secret is produced. It is only consulted when kubedb generates the
+	// secret; a user-supplied (BYO) secret is never regenerated.
+	//
+	// Leave it nil to get generatePassword, which is the right default for
+	// almost every database: see its doc comment for why symbols are excluded.
+	// Set it from a specific database's operator when that database has a
+	// credential policy the shared default cannot express -- for example an
+	// external regulatory requirement for a symbol class -- and when that
+	// database does not render the password into a delimiter-based config.
+	//
+	// The function must return a password of exactly n characters.
+	PasswordGenerator func(n int) string
 }
 
 func (o Options) EnsureAuthSecret(ctx context.Context) error {
@@ -233,9 +246,13 @@ func (o Options) validateAuthData(data map[string][]byte) error {
 }
 
 func (o Options) generatedData() map[string][]byte {
+	gen := generatePassword
+	if o.PasswordGenerator != nil {
+		gen = o.PasswordGenerator
+	}
 	return map[string][]byte{
 		core.BasicAuthUsernameKey: []byte(o.DefaultUsername),
-		core.BasicAuthPasswordKey: []byte(generatePassword(kubedb.DefaultPasswordLength)),
+		core.BasicAuthPasswordKey: []byte(gen(kubedb.DefaultPasswordLength)),
 	}
 }
 

--- a/pkg/controller/secret/auth_secret.go
+++ b/pkg/controller/secret/auth_secret.go
@@ -18,6 +18,8 @@ package secret
 
 import (
 	"context"
+	crand "crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"reflect"
 	"strings"
@@ -30,7 +32,6 @@ import (
 	core "k8s.io/api/core/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/rand"
 	cu "kmodules.xyz/client-go/client"
 	core_util "kmodules.xyz/client-go/core/v1"
 	meta_util "kmodules.xyz/client-go/meta"
@@ -267,27 +268,61 @@ const (
 // letters, lowercase letters, and digits only (no symbols), guaranteeing at
 // least one character from each of those three classes. The three-class
 // guarantee satisfies common "N of 3/4 character classes" complexity
-// policies (e.g. SQL Server's SA password requirement) that rand.String's
-// lowercase-consonants-and-digits-only alphabet cannot. Symbols are
+// policies (e.g. SQL Server's SA password requirement). Symbols are
 // deliberately excluded because several DB configs render the password into
 // delimiter-based formats (e.g. ProxySQL's "user:pass;user:pass"
-// admin_variables line) that punctuation could corrupt.
+// admin_variables line) that punctuation could corrupt. A database that must
+// include a symbol class supplies its own generator via
+// Options.PasswordGenerator.
+//
+// Randomness comes from crypto/rand, not a time-seeded math/rand whose seed is
+// recoverable from the operator's observable start time: this value is a
+// database credential.
 func generatePassword(n int) string {
+	if n <= 0 {
+		return ""
+	}
 	if n < 3 {
-		return rand.String(n)
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = pwAll[cryptoIntn(len(pwAll))]
+		}
+		return string(b)
 	}
 	b := make([]byte, n)
-	b[0] = pwUpper[rand.Intn(len(pwUpper))]
-	b[1] = pwLower[rand.Intn(len(pwLower))]
-	b[2] = pwDigits[rand.Intn(len(pwDigits))]
+	b[0] = pwUpper[cryptoIntn(len(pwUpper))]
+	b[1] = pwLower[cryptoIntn(len(pwLower))]
+	b[2] = pwDigits[cryptoIntn(len(pwDigits))]
 	for i := 3; i < n; i++ {
-		b[i] = pwAll[rand.Intn(len(pwAll))]
+		b[i] = pwAll[cryptoIntn(len(pwAll))]
 	}
-	shuffled := make([]byte, n)
-	for i, p := range rand.Perm(n) {
-		shuffled[p] = b[i]
+	// Fisher-Yates shuffle so the guaranteed characters are not pinned to the front.
+	for i := n - 1; i > 0; i-- {
+		j := cryptoIntn(i + 1)
+		b[i], b[j] = b[j], b[i]
 	}
-	return string(shuffled)
+	return string(b)
+}
+
+// cryptoIntn returns a random int in [0, max) using crypto/rand.
+//
+// There is no error path, no panic, no retry loop and no fallback to a weaker
+// source: crypto/rand.Read is documented never to return an error and to always
+// fill the buffer, because the Go runtime itself crashes irrecoverably if the
+// OS CSPRNG is unavailable -- a condition no userspace code can detect or
+// prevent. The returned error is therefore ignored deliberately.
+//
+// Reducing a 64-bit draw modulo max leaves a bias of at most max/2^64. For the
+// charset lengths used here (<= 64) that is below 4e-18, i.e. far smaller than
+// the chance of an undetected hardware fault, so rejection sampling would add
+// a loop for no measurable gain.
+func cryptoIntn(max int) int {
+	if max <= 0 {
+		return 0
+	}
+	var b [8]byte
+	_, _ = crand.Read(b[:])
+	return int(binary.BigEndian.Uint64(b[:]) % uint64(max))
 }
 
 func activationTime(annotations map[string]string) (*metav1.Time, error) {

--- a/pkg/controller/secret/auth_secret_test.go
+++ b/pkg/controller/secret/auth_secret_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright AppsCode Inc. and Contributors
+
+Licensed under the AppsCode Community License 1.0.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"strings"
+	"testing"
+
+	"kubedb.dev/apimachinery/apis/kubedb"
+
+	core "k8s.io/api/core/v1"
+)
+
+func classesOf(s string) (upper, lower, digit, symbol bool) {
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			upper = true
+		case r >= 'a' && r <= 'z':
+			lower = true
+		case r >= '0' && r <= '9':
+			digit = true
+		default:
+			symbol = true
+		}
+	}
+	return
+}
+
+// The default generator must keep its three-class guarantee and must keep
+// excluding symbols: several databases render the password into
+// delimiter-based config formats that punctuation would corrupt.
+func TestGeneratePasswordDefault(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		pw := generatePassword(kubedb.DefaultPasswordLength)
+		if len(pw) != kubedb.DefaultPasswordLength {
+			t.Fatalf("length = %d, want %d", len(pw), kubedb.DefaultPasswordLength)
+		}
+		upper, lower, digit, symbol := classesOf(pw)
+		if !upper || !lower || !digit {
+			t.Fatalf("missing a required class in %q: upper=%v lower=%v digit=%v", pw, upper, lower, digit)
+		}
+		if symbol {
+			t.Fatalf("default generator emitted a symbol in %q; symbols are deliberately excluded", pw)
+		}
+	}
+}
+
+// A nil PasswordGenerator must leave existing behaviour untouched. This is the
+// path every database other than the one opting in takes.
+func TestGeneratedDataNilGeneratorUsesDefault(t *testing.T) {
+	o := Options{DefaultUsername: "root"}
+	data := o.generatedData()
+
+	if got := string(data[core.BasicAuthUsernameKey]); got != "root" {
+		t.Fatalf("username = %q, want %q", got, "root")
+	}
+	pw := string(data[core.BasicAuthPasswordKey])
+	if len(pw) != kubedb.DefaultPasswordLength {
+		t.Fatalf("length = %d, want %d", len(pw), kubedb.DefaultPasswordLength)
+	}
+	if _, _, _, symbol := classesOf(pw); symbol {
+		t.Fatalf("nil generator produced a symbol in %q", pw)
+	}
+}
+
+// A non-nil PasswordGenerator must be used verbatim, and must receive the
+// configured password length.
+func TestGeneratedDataHonoursPasswordGenerator(t *testing.T) {
+	var gotN int
+	o := Options{
+		DefaultUsername: "postgres",
+		PasswordGenerator: func(n int) string {
+			gotN = n
+			return strings.Repeat("x", n)
+		},
+	}
+	data := o.generatedData()
+
+	if gotN != kubedb.DefaultPasswordLength {
+		t.Fatalf("generator called with n = %d, want %d", gotN, kubedb.DefaultPasswordLength)
+	}
+	if got, want := string(data[core.BasicAuthPasswordKey]), strings.Repeat("x", kubedb.DefaultPasswordLength); got != want {
+		t.Fatalf("password = %q, want %q", got, want)
+	}
+	if got := string(data[core.BasicAuthUsernameKey]); got != "postgres" {
+		t.Fatalf("username = %q, want %q", got, "postgres")
+	}
+}

--- a/pkg/controller/secret/auth_secret_test.go
+++ b/pkg/controller/secret/auth_secret_test.go
@@ -43,9 +43,11 @@ func classesOf(s string) (upper, lower, digit, symbol bool) {
 
 // The default generator must keep its three-class guarantee and must keep
 // excluding symbols: several databases render the password into
-// delimiter-based config formats that punctuation would corrupt.
+// delimiter-based config formats that punctuation would corrupt. It must also
+// not repeat -- a regression to a time-seeded generator would surface here.
 func TestGeneratePasswordDefault(t *testing.T) {
-	for i := 0; i < 200; i++ {
+	seen := make(map[string]struct{}, 500)
+	for i := 0; i < 500; i++ {
 		pw := generatePassword(kubedb.DefaultPasswordLength)
 		if len(pw) != kubedb.DefaultPasswordLength {
 			t.Fatalf("length = %d, want %d", len(pw), kubedb.DefaultPasswordLength)
@@ -57,6 +59,10 @@ func TestGeneratePasswordDefault(t *testing.T) {
 		if symbol {
 			t.Fatalf("default generator emitted a symbol in %q; symbols are deliberately excluded", pw)
 		}
+		if _, dup := seen[pw]; dup {
+			t.Fatalf("duplicate password %q after %d draws", pw, i)
+		}
+		seen[pw] = struct{}{}
 	}
 }
 


### PR DESCRIPTION
Two related changes to the shared auth-secret password generator. Both keep the existing charset, the three-class guarantee, and the symbol exclusion; nothing about a nil-configured caller's output contract changes except the randomness source.

## 1. `generatePassword` now uses `crypto/rand`

It previously drew from `k8s.io/apimachinery/pkg/util/rand`, which is `math/rand` seeded once from `time.Now().UnixNano()` at operator startup:

```go
rand: rand.New(rand.NewSource(time.Now().UnixNano()))
```

That seed is recoverable. The operator pod's start time is visible in its `creationTimestamp`, container-start events, and log timestamps; brute-forcing a one-second nanosecond window is ~10⁹ seeds, microseconds of offline compute. With the seed, the whole stream is reproducible — demonstrated locally, seed recovered in 31,338 tries. For a **database credential** that is not acceptable, independent of exploitation path (an auditor flags `math/rand` in credential code on sight).

The charset and shuffle are unchanged; only the source moves. The shuffle switches `rand.Perm` → in-place Fisher-Yates (crypto/rand has no `Perm`), and the sub-3-char branch (unreachable at the 16-char default) no longer needs `util/rand`. A CSPRNG failure panics rather than silently fall back to a weaker source.

This hardens **every** database using the shared generator — MySQL, MongoDB, Redis, MariaDB, Kafka, etc. — not only the one opting into the hook below.

## 2. Optional `Options.PasswordGenerator` hook

`generatePassword` deliberately excludes symbols, because several databases render the password into delimiter-based config formats (e.g. ProxySQL's `user:pass;user:pass` admin_variables line) that punctuation would corrupt. That default is right for almost every database and does not change.

It cannot, however, express a policy that *mandates* a symbol class. The concrete case is Postgres under Bangladesh Bank ICT Security 8.2.7, enforced in-server by [credcheck](https://github.com/HexaCluster/credcheck) with `password_min_special = 1`: the operator sets the superuser password via `ALTER USER`, credcheck rejects a symbol-free password, the superuser ends up with no password, and after `max_auth_failure` failed logins the role is banned — which also blocks the local socket, leaving no way back in. The cluster sits in `Provisioning` indefinitely.

Rather than weaken the shared default or fork the generator, `Options.PasswordGenerator` lets the affected database supply its own from its own operator, keeping the charset decision next to the database that lives with it.

## Compatibility

The hook is nil by default, so **every existing caller keeps its behaviour**, now with stronger randomness. No database sets the hook in this PR.

## Tests

`pkg/controller/secret/auth_secret_test.go`:
- default generator keeps the three-class guarantee, still emits no symbols, and does not repeat across 500 draws (a regression to a time-seed would surface here)
- nil `PasswordGenerator` produces the default output
- non-nil `PasswordGenerator` is used verbatim and receives `kubedb.DefaultPasswordLength`

## Follow-up

The Postgres consumer is a separate PR in the (private) `kubedb/postgres` repo, blocked on this merging so its `go.mod` can pin to a release.