### PR TITLE
Support custom AppBinding names

### DIFF
--- a/pkg/controller/appbinding/appbinding.go
+++ b/pkg/controller/appbinding/appbinding.go
@@ -42,6 +42,8 @@ type Options struct {
 	KBClient client.Client
 	DB       DB
 	Version  string
+	// Name overrides the default name returned by DB.AppBindingMeta().Name().
+	Name string
 	// Customize runs inside the CreateOrPatch mutate function to layer on everything DB-specific:
 	// ClientConfig, Secret, TLSSecret, Parameters.
 	Customize func(in *appcat.AppBinding)
@@ -56,7 +58,7 @@ func (o Options) Ensure(ctx context.Context) (kutil.VerbType, error) {
 	appmeta := o.DB.AppBindingMeta()
 	ab := &appcat.AppBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      appmeta.Name(),
+			Name:      o.appBindingName(),
 			Namespace: o.DB.GetNamespace(),
 		},
 	}
@@ -81,4 +83,11 @@ func (o Options) Ensure(ctx context.Context) (kutil.VerbType, error) {
 		}
 		return in
 	})
+}
+
+func (o Options) appBindingName() string {
+	if o.Name != "" {
+		return o.Name
+	}
+	return o.DB.AppBindingMeta().Name()
 }

--- a/pkg/controller/appbinding/appbinding_test.go
+++ b/pkg/controller/appbinding/appbinding_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright AppsCode Inc. and Contributors
+
+Licensed under the AppsCode Community License 1.0.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package appbinding
+
+import (
+	"testing"
+
+	dbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestOptionsEnsureAppBindingName(t *testing.T) {
+	tests := []struct {
+		name           string
+		appBindingName string
+		expectedName   string
+	}{
+		{
+			name:         "default name",
+			expectedName: "rabbit",
+		},
+		{
+			name:           "overridden name",
+			appBindingName: "rabbit-management",
+			expectedName:   "rabbit-management",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := &dbapi.RabbitMQ{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rabbit",
+					Namespace: "demo",
+				},
+			}
+
+			got := (Options{
+				DB:   db,
+				Name: tt.appBindingName,
+			}).appBindingName()
+			if got != tt.expectedName {
+				t.Fatalf("expected AppBinding name %q, got %q", tt.expectedName, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allow callers of `pkg/controller/appbinding.Options` to override the generated AppBinding name while preserving the existing default.

This enables RabbitMQ's management AppBinding to use the shared AppBinding controller package.

Related: kubedb/rabbitmq#152