### PR TITLE
Use gomodules.xyz/password-generator for generated auth secret passwords

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	go.uber.org/zap v1.27.0
 	go.virtual-secrets.dev/apimachinery v0.2.0
 	gomodules.xyz/encoding v0.0.8
+	gomodules.xyz/password-generator v0.2.9
 	gomodules.xyz/pointer v0.1.0
 	gomodules.xyz/runtime v0.3.0
 	gomodules.xyz/stow v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -847,6 +847,8 @@ gomodules.xyz/jsonpatch/v2 v2.5.0 h1:JELs8RLM12qJGXU4u/TO3V25KW8GreMKl9pdkk14RM0
 gomodules.xyz/jsonpatch/v2 v2.5.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 gomodules.xyz/mergo v0.3.13 h1:q6cL/MMXZH/MrR2+yjSihFFq6UifXqjwaqI48B6cMEM=
 gomodules.xyz/mergo v0.3.13/go.mod h1:F/2rKC7j0URTnHUKDiTiLcGdLMhdv8jK2Za3cRTUVmc=
+gomodules.xyz/password-generator v0.2.9 h1:qYoXoA61+9zs9A1scffefCgcRGpi9Tw1LsTkIe4bEno=
+gomodules.xyz/password-generator v0.2.9/go.mod h1:TvwYYTx9+P1pPwKQKfZgB/wr2Id9MqAQ3B5auY7reNg=
 gomodules.xyz/pointer v0.1.0 h1:sG2UKrYVSo6E3r4itAjXfPfe4fuXMi0KdyTHpR3vGCg=
 gomodules.xyz/pointer v0.1.0/go.mod h1:sPLsC0+yLTRecUiC5yVlyvXhZ6LAGojNCRWNNqoplvo=
 gomodules.xyz/runtime v0.3.0 h1:Fgf3fjIE3xY/sswO73iRBeR3mundZAjlY42fQPigPR0=

--- a/pkg/controller/secret/auth_secret.go
+++ b/pkg/controller/secret/auth_secret.go
@@ -59,12 +59,11 @@ type Options struct {
 	// secret is produced. It is only consulted when kubedb generates the
 	// secret; a user-supplied (BYO) secret is never regenerated.
 	//
-	// Leave it nil to get generatePassword, which is the right default for
-	// almost every database: see its doc comment for why symbols are excluded.
-	// Set it from a specific database's operator when that database has a
-	// credential policy the shared default cannot express -- for example an
-	// external regulatory requirement for a symbol class -- and when that
-	// database does not render the password into a delimiter-based config.
+	// Leave it nil to get password.Generate, which is the right default for
+	// almost every database. Set it from a specific database's operator when
+	// that database has a credential policy the shared default cannot express
+	// -- for example a charset restriction imposed by a delimiter-based config
+	// format, or a mandated character class.
 	//
 	// The function must return a password of exactly n characters.
 	PasswordGenerator func(n int) string
@@ -246,7 +245,7 @@ func (o Options) validateAuthData(data map[string][]byte) error {
 }
 
 func (o Options) generatedData() map[string][]byte {
-	gen := generatePassword
+	gen := password.Generate
 	if o.PasswordGenerator != nil {
 		gen = o.PasswordGenerator
 	}
@@ -254,16 +253,6 @@ func (o Options) generatedData() map[string][]byte {
 		core.BasicAuthUsernameKey: []byte(o.DefaultUsername),
 		core.BasicAuthPasswordKey: []byte(gen(kubedb.DefaultPasswordLength)),
 	}
-}
-
-// generatePassword returns an n-character alphanumeric password. Symbols are
-// deliberately excluded because several DB configs render the password into
-// delimiter-based formats (e.g. ProxySQL's "user:pass;user:pass"
-// admin_variables line) that punctuation could corrupt. A database that must
-// include a symbol class supplies its own generator via
-// Options.PasswordGenerator.
-func generatePassword(n int) string {
-	return password.GenerateForCharset(n, password.AlphaNum)
 }
 
 func activationTime(annotations map[string]string) (*metav1.Time, error) {

--- a/pkg/controller/secret/auth_secret.go
+++ b/pkg/controller/secret/auth_secret.go
@@ -27,7 +27,7 @@ import (
 	dbsecret "kubedb.dev/apimachinery/pkg/secret"
 
 	vsecretapi "go.virtual-secrets.dev/apimachinery/apis/virtual/v1alpha1"
-	"gomodules.xyz/password-generator"
+	passgen "gomodules.xyz/password-generator"
 	core "k8s.io/api/core/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,7 +59,7 @@ type Options struct {
 	// secret is produced. It is only consulted when kubedb generates the
 	// secret; a user-supplied (BYO) secret is never regenerated.
 	//
-	// Leave it nil to get password.Generate, which is the right default for
+	// Leave it nil to get passgen.Generate, which is the right default for
 	// almost every database. Set it from a specific database's operator when
 	// that database has a credential policy the shared default cannot express
 	// -- for example a charset restriction imposed by a delimiter-based config
@@ -245,7 +245,7 @@ func (o Options) validateAuthData(data map[string][]byte) error {
 }
 
 func (o Options) generatedData() map[string][]byte {
-	gen := password.Generate
+	gen := passgen.Generate
 	if o.PasswordGenerator != nil {
 		gen = o.PasswordGenerator
 	}

--- a/pkg/controller/secret/auth_secret.go
+++ b/pkg/controller/secret/auth_secret.go
@@ -18,8 +18,6 @@ package secret
 
 import (
 	"context"
-	crand "crypto/rand"
-	"encoding/binary"
 	"fmt"
 	"reflect"
 	"strings"
@@ -29,6 +27,7 @@ import (
 	dbsecret "kubedb.dev/apimachinery/pkg/secret"
 
 	vsecretapi "go.virtual-secrets.dev/apimachinery/apis/virtual/v1alpha1"
+	"gomodules.xyz/password-generator"
 	core "k8s.io/api/core/v1"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -257,72 +256,14 @@ func (o Options) generatedData() map[string][]byte {
 	}
 }
 
-const (
-	pwUpper  = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	pwLower  = "abcdefghijklmnopqrstuvwxyz"
-	pwDigits = "0123456789"
-	pwAll    = pwUpper + pwLower + pwDigits
-)
-
-// generatePassword returns an n-character password drawn from uppercase
-// letters, lowercase letters, and digits only (no symbols), guaranteeing at
-// least one character from each of those three classes. The three-class
-// guarantee satisfies common "N of 3/4 character classes" complexity
-// policies (e.g. SQL Server's SA password requirement). Symbols are
+// generatePassword returns an n-character alphanumeric password. Symbols are
 // deliberately excluded because several DB configs render the password into
 // delimiter-based formats (e.g. ProxySQL's "user:pass;user:pass"
 // admin_variables line) that punctuation could corrupt. A database that must
 // include a symbol class supplies its own generator via
 // Options.PasswordGenerator.
-//
-// Randomness comes from crypto/rand, not a time-seeded math/rand whose seed is
-// recoverable from the operator's observable start time: this value is a
-// database credential.
 func generatePassword(n int) string {
-	if n <= 0 {
-		return ""
-	}
-	if n < 3 {
-		b := make([]byte, n)
-		for i := range b {
-			b[i] = pwAll[cryptoIntn(len(pwAll))]
-		}
-		return string(b)
-	}
-	b := make([]byte, n)
-	b[0] = pwUpper[cryptoIntn(len(pwUpper))]
-	b[1] = pwLower[cryptoIntn(len(pwLower))]
-	b[2] = pwDigits[cryptoIntn(len(pwDigits))]
-	for i := 3; i < n; i++ {
-		b[i] = pwAll[cryptoIntn(len(pwAll))]
-	}
-	// Fisher-Yates shuffle so the guaranteed characters are not pinned to the front.
-	for i := n - 1; i > 0; i-- {
-		j := cryptoIntn(i + 1)
-		b[i], b[j] = b[j], b[i]
-	}
-	return string(b)
-}
-
-// cryptoIntn returns a random int in [0, max) using crypto/rand.
-//
-// There is no error path, no panic, no retry loop and no fallback to a weaker
-// source: crypto/rand.Read is documented never to return an error and to always
-// fill the buffer, because the Go runtime itself crashes irrecoverably if the
-// OS CSPRNG is unavailable -- a condition no userspace code can detect or
-// prevent. The returned error is therefore ignored deliberately.
-//
-// Reducing a 64-bit draw modulo max leaves a bias of at most max/2^64. For the
-// charset lengths used here (<= 64) that is below 4e-18, i.e. far smaller than
-// the chance of an undetected hardware fault, so rejection sampling would add
-// a loop for no measurable gain.
-func cryptoIntn(max int) int {
-	if max <= 0 {
-		return 0
-	}
-	var b [8]byte
-	_, _ = crand.Read(b[:])
-	return int(binary.BigEndian.Uint64(b[:]) % uint64(max))
+	return password.GenerateForCharset(n, password.AlphaNum)
 }
 
 func activationTime(annotations map[string]string) (*metav1.Time, error) {

--- a/pkg/controller/secret/auth_secret_test.go
+++ b/pkg/controller/secret/auth_secret_test.go
@@ -25,52 +25,25 @@ import (
 	core "k8s.io/api/core/v1"
 )
 
-func hasSymbol(s string) bool {
-	for _, r := range s {
-		switch {
-		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9':
-		default:
-			return true
-		}
-	}
-	return false
-}
+// A nil PasswordGenerator must fall back to password.Generate. This is the
+// path every database other than the one opting in takes.
+func TestGeneratedDataNilGeneratorUsesDefault(t *testing.T) {
+	o := Options{DefaultUsername: "root"}
+	seen := make(map[string]struct{}, 100)
+	for i := 0; i < 100; i++ {
+		data := o.generatedData()
 
-// The default generator must keep excluding symbols: several databases render
-// the password into delimiter-based config formats that punctuation would
-// corrupt. It must also not repeat.
-func TestGeneratePasswordDefault(t *testing.T) {
-	seen := make(map[string]struct{}, 500)
-	for i := 0; i < 500; i++ {
-		pw := generatePassword(kubedb.DefaultPasswordLength)
+		if got := string(data[core.BasicAuthUsernameKey]); got != "root" {
+			t.Fatalf("username = %q, want %q", got, "root")
+		}
+		pw := string(data[core.BasicAuthPasswordKey])
 		if len(pw) != kubedb.DefaultPasswordLength {
 			t.Fatalf("length = %d, want %d", len(pw), kubedb.DefaultPasswordLength)
-		}
-		if hasSymbol(pw) {
-			t.Fatalf("default generator emitted a symbol in %q; symbols are deliberately excluded", pw)
 		}
 		if _, dup := seen[pw]; dup {
 			t.Fatalf("duplicate password %q after %d draws", pw, i)
 		}
 		seen[pw] = struct{}{}
-	}
-}
-
-// A nil PasswordGenerator must leave existing behaviour untouched. This is the
-// path every database other than the one opting in takes.
-func TestGeneratedDataNilGeneratorUsesDefault(t *testing.T) {
-	o := Options{DefaultUsername: "root"}
-	data := o.generatedData()
-
-	if got := string(data[core.BasicAuthUsernameKey]); got != "root" {
-		t.Fatalf("username = %q, want %q", got, "root")
-	}
-	pw := string(data[core.BasicAuthPasswordKey])
-	if len(pw) != kubedb.DefaultPasswordLength {
-		t.Fatalf("length = %d, want %d", len(pw), kubedb.DefaultPasswordLength)
-	}
-	if hasSymbol(pw) {
-		t.Fatalf("nil generator produced a symbol in %q", pw)
 	}
 }
 

--- a/pkg/controller/secret/auth_secret_test.go
+++ b/pkg/controller/secret/auth_secret_test.go
@@ -25,26 +25,20 @@ import (
 	core "k8s.io/api/core/v1"
 )
 
-func classesOf(s string) (upper, lower, digit, symbol bool) {
+func hasSymbol(s string) bool {
 	for _, r := range s {
 		switch {
-		case r >= 'A' && r <= 'Z':
-			upper = true
-		case r >= 'a' && r <= 'z':
-			lower = true
-		case r >= '0' && r <= '9':
-			digit = true
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9':
 		default:
-			symbol = true
+			return true
 		}
 	}
-	return
+	return false
 }
 
-// The default generator must keep its three-class guarantee and must keep
-// excluding symbols: several databases render the password into
-// delimiter-based config formats that punctuation would corrupt. It must also
-// not repeat -- a regression to a time-seeded generator would surface here.
+// The default generator must keep excluding symbols: several databases render
+// the password into delimiter-based config formats that punctuation would
+// corrupt. It must also not repeat.
 func TestGeneratePasswordDefault(t *testing.T) {
 	seen := make(map[string]struct{}, 500)
 	for i := 0; i < 500; i++ {
@@ -52,11 +46,7 @@ func TestGeneratePasswordDefault(t *testing.T) {
 		if len(pw) != kubedb.DefaultPasswordLength {
 			t.Fatalf("length = %d, want %d", len(pw), kubedb.DefaultPasswordLength)
 		}
-		upper, lower, digit, symbol := classesOf(pw)
-		if !upper || !lower || !digit {
-			t.Fatalf("missing a required class in %q: upper=%v lower=%v digit=%v", pw, upper, lower, digit)
-		}
-		if symbol {
+		if hasSymbol(pw) {
 			t.Fatalf("default generator emitted a symbol in %q; symbols are deliberately excluded", pw)
 		}
 		if _, dup := seen[pw]; dup {
@@ -79,7 +69,7 @@ func TestGeneratedDataNilGeneratorUsesDefault(t *testing.T) {
 	if len(pw) != kubedb.DefaultPasswordLength {
 		t.Fatalf("length = %d, want %d", len(pw), kubedb.DefaultPasswordLength)
 	}
-	if _, _, _, symbol := classesOf(pw); symbol {
+	if hasSymbol(pw) {
 		t.Fatalf("nil generator produced a symbol in %q", pw)
 	}
 }

--- a/vendor/gomodules.xyz/password-generator/.gitignore
+++ b/vendor/gomodules.xyz/password-generator/.gitignore
@@ -1,0 +1,17 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+vendor/
+
+.idea/

--- a/vendor/gomodules.xyz/password-generator/LICENSE
+++ b/vendor/gomodules.xyz/password-generator/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/gomodules.xyz/password-generator/README.md
+++ b/vendor/gomodules.xyz/password-generator/README.md
@@ -1,0 +1,8 @@
+
+[![PkgGoDev](https://pkg.go.dev/badge/gomodules.xyz/password-generator)](https://pkg.go.dev/gomodules.xyz/password-generator)
+![CI](https://github.com/gomodules/password-generator/workflows/CI/badge.svg)
+
+# password-generator
+
+Generates strong random password using algorithm described here:
+https://en.wikipedia.org/wiki/Random_password_generator#JavaScript

--- a/vendor/gomodules.xyz/password-generator/password.go
+++ b/vendor/gomodules.xyz/password-generator/password.go
@@ -1,0 +1,138 @@
+package password
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+type Charset int
+
+const (
+	Uppercase     Charset = 1 << iota // 1 << 0 which is 00000001
+	Lowercase                         // 1 << 1 which is 00000010
+	Numbers                           // 1 << 2 which is 00000100
+	Unreserved                        // 1 << 3 which is 00001000
+	Reserved                          // 1 << 4 which is 00010000
+	SimpleSymbols                     // 1 << 5 which is 00100000
+	Symbols                           // 1 << 6 which is 01000000
+	AlphaNum      = Uppercase | Lowercase | Numbers
+	Default       = Uppercase | Lowercase | Numbers | SimpleSymbols
+)
+
+var (
+	uppercase          = []byte(`ABCDEFGHIJKLMNOPQRSTUVWXYZ`)
+	len_uppercase      = len(uppercase)
+	lowercase          = []byte(`abcdefghijklmnopqrstuvwxyz`)
+	len_lowercase      = len(lowercase)
+	numbers            = []byte(`0123456789`)
+	len_numbers        = len(numbers)
+	unreserved         = []byte(`-._~`) // ref: https://perishablepress.com/stop-using-unsafe-characters-in-urls/
+	len_unreserved     = len(unreserved)
+	reserved           = []byte(`!#$&'()*+,/:;=?@[]`)
+	len_reserved       = len(reserved)
+	simple_symbols     = []byte(`!()*.;_~`) // ref: https://github.com/golang/go/blob/release-branch.go1.15/src/net/url/url.go#L1158-L1186 ,  missing: Unreserved | Reserved - #/?[]':+@,-=$&
+	len_simple_symbols = len(simple_symbols)
+	symbols            = []byte(`!"#$%&'()*+,-./:;<=>?@^[\]_{|}~` + "`")
+	len_symbols        = len(symbols)
+)
+
+func Generate(n int) string {
+	if n <= 2 {
+		return GenerateForCharset(n, AlphaNum)
+	}
+	return GenerateForCharset(1, AlphaNum) + GenerateForCharset(n-2, Default) + GenerateForCharset(1, AlphaNum)
+}
+
+func GenerateForCharset(n int, chset Charset) string {
+	buf := make([]byte, n)
+
+	count := 0
+	if chset&Uppercase != 0 {
+		count += len_uppercase
+	}
+	if chset&Lowercase != 0 {
+		count += len_lowercase
+	}
+	if chset&Numbers != 0 {
+		count += len_numbers
+	}
+	if chset&Unreserved != 0 {
+		count += len_unreserved
+	}
+	if chset&Reserved != 0 {
+		count += len_reserved
+	}
+	if chset&SimpleSymbols != 0 {
+		count += len_simple_symbols
+	}
+	if chset&Symbols != 0 {
+		count += len_symbols
+	}
+	max := big.NewInt(int64(count))
+
+	for i := 0; i < n; i++ {
+		r, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			panic(err)
+		}
+		idx := int(r.Int64())
+
+		if chset&Uppercase != 0 {
+			if idx < len_uppercase {
+				buf[i] = uppercase[idx]
+				continue
+			} else {
+				idx -= len_uppercase
+			}
+		}
+		if chset&Lowercase != 0 {
+			if idx < len_lowercase {
+				buf[i] = lowercase[idx]
+				continue
+			} else {
+				idx -= len_lowercase
+			}
+		}
+		if chset&Numbers != 0 {
+			if idx < len_numbers {
+				buf[i] = numbers[idx]
+				continue
+			} else {
+				idx -= len_numbers
+			}
+		}
+		if chset&Unreserved != 0 {
+			if idx < len_unreserved {
+				buf[i] = unreserved[idx]
+				continue
+			} else {
+				idx -= len_unreserved
+			}
+		}
+		if chset&Reserved != 0 {
+			if idx < len_reserved {
+				buf[i] = reserved[idx]
+				continue
+			} else {
+				idx -= len_reserved
+			}
+		}
+		if chset&SimpleSymbols != 0 {
+			if idx < len_simple_symbols {
+				buf[i] = simple_symbols[idx]
+				continue
+			} else {
+				idx -= len_simple_symbols
+			}
+		}
+		if chset&Symbols != 0 {
+			if idx < len_symbols {
+				buf[i] = symbols[idx]
+				continue
+			} else {
+				idx -= len_symbols
+			}
+		}
+	}
+	return string(buf)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1328,6 +1328,9 @@ gomodules.xyz/jsonpatch/v2
 # gomodules.xyz/mergo v0.3.13
 ## explicit; go 1.13
 gomodules.xyz/mergo
+# gomodules.xyz/password-generator v0.2.9
+## explicit; go 1.15
+gomodules.xyz/password-generator
 # gomodules.xyz/pointer v0.1.0
 ## explicit; go 1.15
 gomodules.xyz/pointer


### PR DESCRIPTION
Replace the hand-rolled charset/Fisher-Yates/`cryptoIntn` password generator in `pkg/controller/secret` with `gomodules.xyz/password-generator`, the package the database operators used before auth-secret handling moved into this shared package (e.g. `passgen.Generate(kubedb.DefaultPasswordLength)` in kubedb/postgres#921's removed code).

- `generatedData` now defaults to `password.Generate`; the `generatePassword` helper is gone.
- Per-database `Options.PasswordGenerator` override is unchanged (postgres still supplies its own).
- Adds `gomodules.xyz/password-generator v0.2.9` to go.mod + vendor.

Behavior change: the removed generator was alphanumeric-only and guaranteed one uppercase, lowercase and digit each. `password.Generate` draws the interior characters from upper|lower|digits|SimpleSymbols (`!()*.;_~`) with alphanumeric first/last characters, so generated passwords can now contain those symbols — same as what each operator produced pre-migration. Tests updated accordingly.

`go build ./...` and `go test ./pkg/controller/secret/...` pass.