### PR TITLE
Support management AppBinding metadata

### DIFF
--- a/apis/kubedb/v1alpha2/openapi_generated.go
+++ b/apis/kubedb/v1alpha2/openapi_generated.go
@@ -45027,8 +45027,15 @@ func schema_apimachinery_apis_kubedb_v1alpha2_RabbitmqApp(ref common.ReferenceCa
 							Ref: ref("kubedb.dev/apimachinery/apis/kubedb/v1alpha2.RabbitMQ"),
 						},
 					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 				},
-				Required: []string{"RabbitMQ"},
+				Required: []string{"RabbitMQ", "name"},
 			},
 		},
 		Dependencies: []string{

--- a/apis/kubedb/v1alpha2/rabbitmq_helpers.go
+++ b/apis/kubedb/v1alpha2/rabbitmq_helpers.go
@@ -53,9 +53,13 @@ func (r *RabbitMQ) CustomResourceDefinition() *apiextensions.CustomResourceDefin
 
 type RabbitmqApp struct {
 	*RabbitMQ
+	name string
 }
 
 func (r RabbitmqApp) Name() string {
+	if r.name != "" {
+		return r.name
+	}
 	return r.RabbitMQ.Name
 }
 
@@ -64,7 +68,14 @@ func (r RabbitmqApp) Type() appcat.AppType {
 }
 
 func (r *RabbitMQ) AppBindingMeta() appcat.AppBindingMeta {
-	return &RabbitmqApp{r}
+	return &RabbitmqApp{RabbitMQ: r}
+}
+
+func (r *RabbitMQ) ManagementAppBindingMeta() appcat.AppBindingMeta {
+	return &RabbitmqApp{
+		RabbitMQ: r,
+		name:     meta_util.NameWithSuffix(r.AppBindingMeta().Name(), "management"),
+	}
 }
 
 func (r *RabbitMQ) GetConnectionScheme() string {
@@ -97,10 +108,6 @@ func (r *RabbitMQ) GetAMQPConnectionURL(username, password string) string {
 func (r *RabbitMQ) GetManagementConnectionURL() string {
 	scheme, port := r.GetManagementEndpoint()
 	return fmt.Sprintf("%s://%s.%s.svc.%s:%d", scheme, r.DashboardServiceName(), r.Namespace, apiutils.FindDomain(), port)
-}
-
-func (r *RabbitMQ) GetManagementAppBindingName() string {
-	return meta_util.NameWithSuffix(r.AppBindingMeta().Name(), "management")
 }
 
 func (r *RabbitMQ) GetAuthSecretName() string {

--- a/pkg/controller/appbinding/appbinding.go
+++ b/pkg/controller/appbinding/appbinding.go
@@ -39,9 +39,10 @@ type DB interface {
 }
 
 type Options struct {
-	KBClient client.Client
-	DB       DB
-	Version  string
+	KBClient       client.Client
+	DB             DB
+	Version        string
+	AppBindingMeta appcat.AppBindingMeta
 	// Customize runs inside the CreateOrPatch mutate function to layer on everything DB-specific:
 	// ClientConfig, Secret, TLSSecret, Parameters.
 	Customize func(in *appcat.AppBinding)
@@ -53,7 +54,10 @@ func (o Options) Ensure(ctx context.Context) (kutil.VerbType, error) {
 		return kutil.VerbUnchanged, err
 	}
 
-	appmeta := o.DB.AppBindingMeta()
+	appmeta := o.AppBindingMeta
+	if appmeta == nil {
+		appmeta = o.DB.AppBindingMeta()
+	}
 	ab := &appcat.AppBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      appmeta.Name(),


### PR DESCRIPTION
Allow the shared AppBinding controller to use database-specific AppBinding metadata.

Add RabbitMQ management AppBinding metadata and endpoint helpers for the management AppBinding.