### PR TITLE
Add PostgresCustomHBAFile constant for user-supplied pg_hba rules

### DIFF
--- a/apis/kubedb/constants.go
+++ b/apis/kubedb/constants.go
@@ -555,11 +555,18 @@ const (
 	PostgresSharedTlsVolumeName      = "certs"
 	PostgresSharedTlsVolumeMountPath = "/tls/certs"
 	PostgresCustomConfigFile         = "user.conf"
-	PostgresTuningConfigFile         = "pgtune.conf"
-	PostgresKeyFileSecretSuffix      = "key"
-	PostgresPEMSecretSuffix          = "pem"
-	PostgresDefaultUsername          = "postgres"
-	PostgresPgCoordinatorStatus      = "Coordinator/Status"
+	// PostgresCustomHBAFile is the optional configSecret key whose content is
+	// surfaced to the DB pod as /etc/config/user_hba.conf. postgres-init-docker
+	// splices it into the generated pg_hba.conf between the operator-essential
+	// local/loopback rules and the world-CIDR catch-alls, so user rules can
+	// override the catch-alls (pg_hba.conf is first-match-wins) but cannot lock
+	// the operator out.
+	PostgresCustomHBAFile       = "user_hba.conf"
+	PostgresTuningConfigFile    = "pgtune.conf"
+	PostgresKeyFileSecretSuffix = "key"
+	PostgresPEMSecretSuffix     = "pem"
+	PostgresDefaultUsername     = "postgres"
+	PostgresPgCoordinatorStatus = "Coordinator/Status"
 	// to pause the failover for postgres. this is helpful for ops request
 	PostgresPgCoordinatorStatusPause = "Pause"
 	// to resume the failover for postgres. this is helpful for ops request

--- a/apis/kubedb/v1/postgres_helpers.go
+++ b/apis/kubedb/v1/postgres_helpers.go
@@ -729,3 +729,61 @@ func (p *Postgres) GetDeletionPolicy() string {
 func (p *Postgres) GetPersistentSecrets() []string {
 	return p.Spec.GetPersistentSecrets()
 }
+
+// hbaConnectionTypes are the connection types PostgreSQL accepts in the first column of a
+// pg_hba.conf record. "local" is deliberately absent: see ValidateHBAConfig.
+var hbaConnectionTypes = map[string]bool{
+	"host":         true,
+	"hostssl":      true,
+	"hostnossl":    true,
+	"hostgssenc":   true,
+	"hostnogssenc": true,
+}
+
+// ValidateHBAConfig validates user supplied pg_hba.conf records before they are spliced into
+// the generated $PGDATA/pg_hba.conf by postgres-init-docker's role scripts.
+//
+// pg_hba.conf is first-match-wins and the user block is spliced above KubeDB's catch-all
+// rules, which is what lets a user tighten access. That same position means a permissive user
+// record can shadow a KubeDB record, so the rules KubeDB depends on are not negotiable:
+//
+//   - "local" records are rejected. KubeDB's own local trust rules sit above the user block and
+//     would win anyway, so accepting these would silently do nothing.
+//   - records for the "replication" pseudo-database are rejected. They sit above KubeDB's
+//     replication rules, so "host replication all 0.0.0.0/0 trust" would hand out unauthenticated
+//     replication - a full copy of the cluster.
+//   - include/include_if_exists/include_dir are rejected. PostgreSQL only honours them from
+//     major 16 and the catalog ships 10-18, so they would be a silent no-op on most versions.
+//
+// The role scripts filter local/replication again as defence in depth, for the case where the
+// webhook is bypassed. Callers outside the webhook package (pkg/ops) use this too, which is why
+// it lives here rather than in pkg/webhooks.
+func ValidateHBAConfig(content string) error {
+	for i, raw := range strings.Split(content, "\n") {
+		lineNo := i + 1
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		connType := strings.ToLower(fields[0])
+
+		if strings.HasPrefix(connType, "include") {
+			return fmt.Errorf("pg_hba.conf line %d: %q is not allowed; PostgreSQL only supports include directives in pg_hba.conf from major version 16 and KubeDB supports 10-18, so it would be silently ignored", lineNo, fields[0])
+		}
+		if connType == "local" {
+			return fmt.Errorf("pg_hba.conf line %d: %q records are not allowed; KubeDB's own local rules are matched first, so this would never take effect", lineNo, "local")
+		}
+		if !hbaConnectionTypes[connType] {
+			return fmt.Errorf("pg_hba.conf line %d: unknown connection type %q", lineNo, fields[0])
+		}
+		// host<type> database user address method
+		if len(fields) < 5 {
+			return fmt.Errorf("pg_hba.conf line %d: expected at least 5 fields (type database user address method), got %d: %q", lineNo, len(fields), line)
+		}
+		if strings.EqualFold(fields[1], "replication") {
+			return fmt.Errorf("pg_hba.conf line %d: rules for the %q database are reserved for KubeDB; a permissive rule here would expose unauthenticated replication", lineNo, "replication")
+		}
+	}
+	return nil
+}

--- a/pkg/webhooks/kubedb/v1/postgres.go
+++ b/pkg/webhooks/kubedb/v1/postgres.go
@@ -493,12 +493,8 @@ func (wh *PostgresCustomWebhook) validate(postgres *dbapi.Postgres) (admission.W
 	}
 
 	if postgres.Spec.Configuration != nil && len(postgres.Spec.Configuration.Inline) > 0 {
-		if len(postgres.Spec.Configuration.Inline) > 1 {
-			return nil, fmt.Errorf(`only one configuration source is allowed in spec.configuration.applyConfig and it should be %q`, kubedb.PostgresCustomConfigFile)
-		}
-		_, exists := postgres.Spec.Configuration.Inline[kubedb.PostgresCustomConfigFile]
-		if !exists {
-			return nil, fmt.Errorf(`invalid configuration source found in spec.configuration.applyConfig. only %q is allowed`, kubedb.PostgresCustomConfigFile)
+		if err := validatePostgresInlineConfig(postgres.Spec.Configuration.Inline); err != nil {
+			return nil, err
 		}
 	}
 
@@ -647,6 +643,31 @@ func checkPgScramAuthMethodSupport(v string) error {
 	}
 	if pgVersion.Major() < 11 {
 		return fmt.Errorf("scram auth method is available only for 11 or higher Versions")
+	}
+	return nil
+}
+
+// validatePostgresInlineConfig checks the keys of spec.configuration.inline (and the identically
+// shaped applyConfig on a PostgresOpsRequest). Two keys are recognised:
+//
+//	user.conf     -> appended to postgresql.conf via include_if_exists
+//	user_hba.conf -> spliced into $PGDATA/pg_hba.conf by the role scripts
+//
+// Anything else is rejected rather than silently dropped, which is what makes a mistyped key a
+// visible failure instead of a cluster that starts fine and ignores every setting.
+func validatePostgresInlineConfig(inline map[string]string) error {
+	for key, val := range inline {
+		switch key {
+		case kubedb.PostgresCustomConfigFile:
+			// postgresql.conf settings; PostgreSQL itself reports bad entries on reload.
+		case kubedb.PostgresCustomHBAFile:
+			if err := dbapi.ValidateHBAConfig(val); err != nil {
+				return fmt.Errorf("invalid %q in spec.configuration.inline: %w", kubedb.PostgresCustomHBAFile, err)
+			}
+		default:
+			return fmt.Errorf("invalid configuration source %q found in spec.configuration.inline; only %q and %q are allowed",
+				key, kubedb.PostgresCustomConfigFile, kubedb.PostgresCustomHBAFile)
+		}
 	}
 	return nil
 }

--- a/pkg/webhooks/ops/v1alpha1/postgres.go
+++ b/pkg/webhooks/ops/v1alpha1/postgres.go
@@ -291,15 +291,25 @@ func (w *PostgresOpsRequestCustomWebhook) validatePostgresReconfigureOpsRequest(
 		return errors.New("`spec.configuration` nil not supported in Reconfigure type")
 	}
 
-	if !req.Spec.Configuration.RemoveCustomConfig && req.Spec.Configuration.ConfigSecret == nil && !applyConfigExistsForPostgres(req.Spec.Configuration.ApplyConfig) && req.Spec.Configuration.Tuning == nil {
-		return errors.New("at least one of `RemoveCustomConfig`, `ConfigSecret`, `Tuning` or `ApplyConfig` must be specified")
+	// Validate the applyConfig keys before the "at least one of ..." precondition below. An
+	// unknown key makes applyConfigExistsForPostgres false, so checking the precondition first
+	// would tell the user nothing was specified when they clearly specified applyConfig.
+	for key, val := range req.Spec.Configuration.ApplyConfig {
+		switch key {
+		case kubedb.PostgresCustomConfigFile:
+			// postgresql.conf settings; PostgreSQL reports bad entries itself on reload.
+		case kubedb.PostgresCustomHBAFile:
+			if err := dbapi.ValidateHBAConfig(val); err != nil {
+				return fmt.Errorf("invalid %q in `spec.configuration.applyConfig`: %w", kubedb.PostgresCustomHBAFile, err)
+			}
+		default:
+			return fmt.Errorf("invalid configuration source %q in `spec.configuration.applyConfig`; only %q and %q are allowed",
+				key, kubedb.PostgresCustomConfigFile, kubedb.PostgresCustomHBAFile)
+		}
 	}
 
-	if applyConfigExistsForPostgres(req.Spec.Configuration.ApplyConfig) {
-		_, ok := req.Spec.Configuration.ApplyConfig[kubedb.PostgresCustomConfigFile]
-		if !ok {
-			return fmt.Errorf("`spec.configuration.applyConfig` does not have file named '%v'", kubedb.PostgresCustomConfigFile)
-		}
+	if !req.Spec.Configuration.RemoveCustomConfig && req.Spec.Configuration.ConfigSecret == nil && !applyConfigExistsForPostgres(req.Spec.Configuration.ApplyConfig) && req.Spec.Configuration.Tuning == nil {
+		return errors.New("at least one of `RemoveCustomConfig`, `ConfigSecret`, `Tuning` or `ApplyConfig` must be specified")
 	}
 
 	if req.Spec.Configuration.Restart == opsapi.ReconfigureRestartFalse && req.Spec.Configuration.RemoveCustomConfig {
@@ -465,11 +475,18 @@ func (w *PostgresOpsRequestCustomWebhook) validatePostgresVolumeExpansionOpsRequ
 	return nil
 }
 
+// applyConfigExistsForPostgres reports whether the request carries any recognised config key.
+// Either key counts on its own: a Reconfigure may touch only postgresql.conf settings, only
+// pg_hba.conf rules, or both. Checking user.conf alone made an hba-only request look empty and
+// fail the "at least one of ..." precondition.
 func applyConfigExistsForPostgres(applyConfig map[string]string) bool {
 	if applyConfig == nil {
 		return false
 	}
-	_, exists := applyConfig[kubedb.PostgresCustomConfigFile]
+	if _, exists := applyConfig[kubedb.PostgresCustomConfigFile]; exists {
+		return true
+	}
+	_, exists := applyConfig[kubedb.PostgresCustomHBAFile]
 	return exists
 }
 


### PR DESCRIPTION
Names the configSecret key (`user_hba.conf`) that carries user-supplied `pg_hba.conf` rules.

Companion PRs consume it:
- kubedb/postgres-init-docker: splices the file into the generated `pg_hba.conf` between the operator-essential local/loopback rules and the world-CIDR catch-alls (`pg_hba.conf` is first-match-wins, so this is the position where user rules can override the catch-alls without being able to lock the operator out).
- kubedb/postgres: projects the key into `/etc/config` as a separate optional source.

Constant-only change; no behavior.