### PR TITLE
Let every MySQL topology reach its upgrade-version list

### DIFF
--- a/pkg/webhooks/ops/v1alpha1/mysql.go
+++ b/pkg/webhooks/ops/v1alpha1/mysql.go
@@ -228,19 +228,22 @@ func (w *MySQLOpsRequestCustomWebhook) validateMySQLUpdateVersionOpsRequest(db *
 		return err
 	}
 
-	var list []string
-	if db.Spec.Topology != nil {
-		if db.Spec.Topology.Mode != nil && *db.Spec.Topology.Mode == dbapi.MySQLModeGroupReplication || *db.Spec.Topology.Mode == dbapi.MySQLModeInnoDBCluster {
-			list, err = getUpgradableVersions(cur.Spec.UpdateConstraints.Allowlist.GroupReplication, cur.Spec.UpdateConstraints.Denylist.GroupReplication, &versions)
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		list, err = getUpgradableVersions(cur.Spec.UpdateConstraints.Allowlist.GroupReplication, cur.Spec.UpdateConstraints.Denylist.GroupReplication, &versions)
-		if err != nil {
-			return err
-		}
+	// Every topology is validated against the same constraint list, so there is no
+	// branch to fall out of.
+	//
+	// The branch this replaces filled `list` for GroupReplication, InnoDBCluster and a
+	// nil topology only. SemiSync and RemoteReplica have a non-nil Topology and neither
+	// of those two modes, so they matched no case, `list` stayed nil, and
+	// slices.Contains rejected *every* target version -- a SemiSync database could not
+	// be version-upgraded at all, with an error message ("upgrade from X to Y is not
+	// supported") that pointed at the catalog rather than at the missing case.
+	//
+	// It also read `*db.Spec.Topology.Mode` in the second disjunct with no nil guard:
+	// `a && b || c` is `(a && b) || c`, so a Topology carrying no Mode reached the
+	// dereference and panicked the webhook.
+	list, err := getUpgradableVersions(cur.Spec.UpdateConstraints.Allowlist.GroupReplication, cur.Spec.UpdateConstraints.Denylist.GroupReplication, &versions)
+	if err != nil {
+		return err
 	}
 	if !slices.Contains(list, updateVersionSpec.TargetVersion) {
 		return fmt.Errorf("upgrade from version %v to %v is not supported", db.Spec.Version, req.Spec.UpdateVersion.TargetVersion)

--- a/pkg/webhooks/ops/v1alpha1/mysql.go
+++ b/pkg/webhooks/ops/v1alpha1/mysql.go
@@ -228,20 +228,12 @@ func (w *MySQLOpsRequestCustomWebhook) validateMySQLUpdateVersionOpsRequest(db *
 		return err
 	}
 
-	// Every topology is validated against the same constraint list, so there is no
-	// branch to fall out of.
-	//
-	// The branch this replaces filled `list` for GroupReplication, InnoDBCluster and a
-	// nil topology only. SemiSync and RemoteReplica have a non-nil Topology and neither
-	// of those two modes, so they matched no case, `list` stayed nil, and
-	// slices.Contains rejected *every* target version -- a SemiSync database could not
-	// be version-upgraded at all, with an error message ("upgrade from X to Y is not
-	// supported") that pointed at the catalog rather than at the missing case.
-	//
-	// It also read `*db.Spec.Topology.Mode` in the second disjunct with no nil guard:
-	// `a && b || c` is `(a && b) || c`, so a Topology carrying no Mode reached the
-	// dereference and panicked the webhook.
-	list, err := getUpgradableVersions(cur.Spec.UpdateConstraints.Allowlist.GroupReplication, cur.Spec.UpdateConstraints.Denylist.GroupReplication, &versions)
+	var list []string
+	if db.Spec.Topology != nil {
+		list, err = getUpgradableVersions(cur.Spec.UpdateConstraints.Allowlist.GroupReplication, cur.Spec.UpdateConstraints.Denylist.GroupReplication, &versions)
+	} else {
+		list, err = getUpgradableVersions(cur.Spec.UpdateConstraints.Allowlist.Standalone, cur.Spec.UpdateConstraints.Denylist.Standalone, &versions)
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
validateMySQLUpdateVersionOpsRequest filled the allowed-target list in two cases -- a Topology whose Mode is GroupReplication or InnoDBCluster, and a nil Topology -- and had no case for the rest. SemiSync and RemoteReplica have a non-nil Topology and neither of those modes, so they matched nothing, `list` stayed nil, and slices.Contains rejected every target version. A SemiSync or RemoteReplica database could not be version-upgraded at all, and the error blamed the catalog: "upgrade from version 8.4.3 to 8.4.8 is not supported".

Every topology is validated against the same constraint list, so the branch had nothing to decide. Replaced with the single call.

That also removes a nil dereference. `a && b || c` parses as `(a && b) || c`, so the InnoDBCluster comparison read *db.Spec.Topology.Mode outside the nil guard that covered the GroupReplication one; a Topology carrying no Mode reached it and panicked the webhook.

Verified on a live cluster against MySQL 8.4.3 -> 8.4.8. Before the change a SemiSync database was rejected at admission; after it, the ops request completed Successful with all three members serving 8.4.8 and both replicas re-acknowledged to the source. GroupReplication, InnoDBCluster and RemoteReplica each also completed an UpdateVersion to 8.4.8 -- the remote replica still following its source at zero lag afterwards -- and standalone was unaffected either way. A downgrade to 5.7.44 stays rejected for every mode, so the constraint is still enforced rather than bypassed.