### PR TITLE
Add Enterprise distribution for MongoDBVersion

### DIFF
--- a/apis/catalog/v1alpha1/mongodb_version_types.go
+++ b/apis/catalog/v1alpha1/mongodb_version_types.go
@@ -133,7 +133,7 @@ type MongoDBVersionList struct {
 	Items []MongoDBVersion `json:"items,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=Official;Percona;KubeDB;MongoDB
+// +kubebuilder:validation:Enum=Official;Percona;KubeDB;MongoDB;Enterprise
 type MongoDBDistro string
 
 const (
@@ -141,4 +141,14 @@ const (
 	MongoDBDistroPercona   MongoDBDistro = "Percona"
 	MongoDBDistroKubeDB    MongoDBDistro = "KubeDB"
 	MongoDBDistroMongoDB   MongoDBDistro = "MongoDB"
+	// MongoDBDistroEnterprise is MongoDB Inc.'s official mongodb/mongodb-enterprise-server
+	// build (LDAP, Kerberos, encryption-at-rest, auditing, SNMP, queryable encryption, etc.).
+	// It requires no runtime license file: MongoDB Enterprise Server has no license-key
+	// enforcement built into the binary, unlike e.g. the AppsCode Postgres Enterprise
+	// distribution. Using it in production requires a commercial MongoDB Enterprise
+	// Advanced subscription, but that is a contractual obligation, not something this
+	// operator can or needs to enforce technically. The image shares its entrypoint
+	// with MongoDBDistroMongoDB (mongodb/mongodb-community-server), so it is handled
+	// identically wherever that distro is branched on (see usesOfficialMongoDBEntrypoint).
+	MongoDBDistroEnterprise MongoDBDistro = "Enterprise"
 )

--- a/crds/catalog.kubedb.com_mongodbversions.yaml
+++ b/crds/catalog.kubedb.com_mongodbversions.yaml
@@ -146,6 +146,7 @@ spec:
                 - Percona
                 - KubeDB
                 - MongoDB
+                - Enterprise
                 type: string
               endOfLife:
                 type: boolean


### PR DESCRIPTION
## What this does

Adds `MongoDBDistroEnterprise` ("Enterprise") to the `MongoDBDistro` enum, mapping to MongoDB Inc.'s official `mongodb/mongodb-enterprise-server` image (LDAP, Kerberos, encryption-at-rest, auditing, SNMP, queryable encryption, etc.).

## Why no license field

Unlike the AppsCode Postgres Enterprise distribution (`PostgresDistroAppsCode` + `PostgresVersionLicense`), this distro needs no license field or secret reference. MongoDB Enterprise Server has no runtime license-key enforcement built into the binary — confirmed directly by MongoDB staff on their community forum ("There is currently no formal license compliance or restrictions baked into MongoDB Enterprise server, so you do not have to manage license key files or expiry."). Using it in production requires a commercial MongoDB Enterprise Advanced subscription, but that's a contractual matter between the user and MongoDB Inc., not something this operator can or needs to enforce technically.

`mongodb/mongodb-enterprise-server` is also a publicly pullable image (same Docker Hub/quay.io `mongodb` org, same tooling as `mongodb-community-server`), so no image-pull-secret handling is needed either.

## Changes

- `apis/catalog/v1alpha1/mongodb_version_types.go`: new `MongoDBDistroEnterprise` const + updated kubebuilder enum validation.
- `crds/catalog.kubedb.com_mongodbversions.yaml`: regenerated enum list.

## Related

Companion operator-side PR: kubedb/mongodb (adds `Enterprise` to the existing distro branch that skips the operator's own `--auth` flag, since the Enterprise image shares its entrypoint with the Community image).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Enterprise MongoDB distribution.
  * MongoDB version configurations can now specify `Enterprise` as an allowed distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->