### PR TITLE
Enforce unique database name per namespace across kubedb kinds

### DIFF
--- a/pkg/validator/name_uniqueness.go
+++ b/pkg/validator/name_uniqueness.go
@@ -1,0 +1,95 @@
+/*
+Copyright AppsCode Inc. and Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validator
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+
+	"kubedb.dev/apimachinery/apis/kubedb"
+
+	kerr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// The same database is served under multiple versions; querying the highest one is enough.
+var kubedbVersionPriority = map[string]int{
+	"v1":       3,
+	"v1alpha2": 2,
+	"v1alpha1": 1,
+}
+
+var clientObjectType = reflect.TypeOf((*client.Object)(nil)).Elem()
+
+func ValidateNameUniqueness(ctx context.Context, kc client.Client, obj runtime.Object) error {
+	db, ok := obj.(client.Object)
+	if !ok {
+		return fmt.Errorf("expected a client.Object but got a %T", obj)
+	}
+	gvk, err := kc.GroupVersionKindFor(db)
+	if err != nil {
+		return err
+	}
+
+	for _, candidate := range otherKubeDBKinds(kc.Scheme(), gvk.Kind) {
+		existing := unstructured.Unstructured{}
+		existing.SetGroupVersionKind(candidate)
+		err := kc.Get(ctx, client.ObjectKey{Namespace: db.GetNamespace(), Name: db.GetName()}, &existing)
+		if err != nil {
+			if kerr.IsNotFound(err) || meta.IsNoMatchError(err) {
+				continue
+			}
+			return err
+		}
+		return fmt.Errorf("cannot create %s %s/%s, a %s already exists with the same name in this namespace",
+			gvk.Kind, db.GetNamespace(), db.GetName(), candidate.Kind)
+	}
+	return nil
+}
+
+func otherKubeDBKinds(scheme *runtime.Scheme, skipKind string) []schema.GroupVersionKind {
+	preferred := make(map[string]schema.GroupVersionKind)
+	for gvk, typ := range scheme.AllKnownTypes() {
+		if gvk.Group != kubedb.GroupName || gvk.Kind == skipKind {
+			continue
+		}
+		// filters out the list kinds & the option kinds registered by metav1.AddToGroupVersion
+		if !reflect.PointerTo(typ).Implements(clientObjectType) {
+			continue
+		}
+		if cur, found := preferred[gvk.Kind]; found &&
+			kubedbVersionPriority[cur.Version] >= kubedbVersionPriority[gvk.Version] {
+			continue
+		}
+		preferred[gvk.Kind] = gvk
+	}
+
+	kinds := make([]schema.GroupVersionKind, 0, len(preferred))
+	for _, gvk := range preferred {
+		kinds = append(kinds, gvk)
+	}
+	sort.Slice(kinds, func(i, j int) bool {
+		return kinds[i].Kind < kinds[j].Kind
+	})
+	return kinds
+}

--- a/pkg/webhooks/kubedb/v1/elasticsearch.go
+++ b/pkg/webhooks/kubedb/v1/elasticsearch.go
@@ -316,6 +316,9 @@ func (w *ElasticsearchCustomWebhook) ValidateCreate(ctx context.Context, obj run
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	es := obj.(*dbapi.Elasticsearch)
 	err := w.ValidateElasticsearch(es)
 	mysqlLog.Info("validating", "name", es.Name)

--- a/pkg/webhooks/kubedb/v1/kafka.go
+++ b/pkg/webhooks/kubedb/v1/kafka.go
@@ -24,6 +24,7 @@ import (
 	catalog "kubedb.dev/apimachinery/apis/catalog/v1alpha1"
 	"kubedb.dev/apimachinery/apis/kubedb"
 	dbapi "kubedb.dev/apimachinery/apis/kubedb/v1"
+	amv "kubedb.dev/apimachinery/pkg/validator"
 
 	errors2 "github.com/pkg/errors"
 	"gomodules.xyz/pointer"
@@ -81,6 +82,9 @@ var _ webhook.CustomValidator = &KafkaCustomWebhook{}
 func (w *KafkaCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	if isDeletionInProgress(obj) {
 		return nil, nil
+	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
 	}
 	db, ok := obj.(*dbapi.Kafka)
 	if !ok {

--- a/pkg/webhooks/kubedb/v1/mariadb.go
+++ b/pkg/webhooks/kubedb/v1/mariadb.go
@@ -142,6 +142,9 @@ func (w MariaDBCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Ob
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	mariadb := obj.(*dbapi.MariaDB)
 	mariadbLog.Info("validating", "name", mariadb.Name)
 

--- a/pkg/webhooks/kubedb/v1/memcached.go
+++ b/pkg/webhooks/kubedb/v1/memcached.go
@@ -287,6 +287,9 @@ func (mv MemcachedCustomWebhook) ValidateCreate(ctx context.Context, obj runtime
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, mv.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	memcached := obj.(*dbapi.Memcached)
 	memLog.Info("validating", "name", memcached.Name)
 	return mv.validate(ctx, obj)

--- a/pkg/webhooks/kubedb/v1/mongodb.go
+++ b/pkg/webhooks/kubedb/v1/mongodb.go
@@ -101,6 +101,9 @@ func (w MongoDBCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Ob
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	log := logf.FromContext(ctx)
 	log.Info("creating MongoDB")
 	return nil, w.ValidateMongoDB(obj.(*dbapi.MongoDB))

--- a/pkg/webhooks/kubedb/v1/mysql.go
+++ b/pkg/webhooks/kubedb/v1/mysql.go
@@ -100,6 +100,9 @@ func (w MySQLCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Obje
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	mysql := obj.(*dbapi.MySQL)
 	err = w.ValidateMySQL(mysql)
 	mysqlLog.Info("validating", "name", mysql.Name)

--- a/pkg/webhooks/kubedb/v1/perconaxtradb.go
+++ b/pkg/webhooks/kubedb/v1/perconaxtradb.go
@@ -93,6 +93,9 @@ func (w PerconaXtraDBCustomWebhook) ValidateCreate(ctx context.Context, obj runt
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	perconaxtradb := obj.(*dbapi.PerconaXtraDB)
 	err = w.ValidatePerconaXtraDB(perconaxtradb)
 	pxlLog.Info("validating", "name", perconaxtradb.GetName())

--- a/pkg/webhooks/kubedb/v1/pgbouncer.go
+++ b/pkg/webhooks/kubedb/v1/pgbouncer.go
@@ -124,6 +124,9 @@ func (pw PgBouncerCustomWebhook) ValidateCreate(ctx context.Context, obj runtime
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, pw.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	pgBouncer, ok := obj.(*dbapi.PgBouncer)
 	if !ok {
 		return nil, fmt.Errorf("expected a PgBouncer but got a %T", pgBouncer)

--- a/pkg/webhooks/kubedb/v1/postgres.go
+++ b/pkg/webhooks/kubedb/v1/postgres.go
@@ -609,6 +609,9 @@ func (wh *PostgresCustomWebhook) ValidateCreate(ctx context.Context, obj runtime
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, wh.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	postgres, ok := obj.(*dbapi.Postgres)
 	if !ok {
 		return nil, fmt.Errorf("expected a Postgres but got a %T", obj)

--- a/pkg/webhooks/kubedb/v1/proxysql.go
+++ b/pkg/webhooks/kubedb/v1/proxysql.go
@@ -91,6 +91,9 @@ func (w ProxySQLCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.O
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	proxysql := obj.(*dbapi.ProxySQL)
 	proxyLog.Info("validating", "name", proxysql.Name)
 	err = w.ValidateProxySQL(proxysql)

--- a/pkg/webhooks/kubedb/v1/redis.go
+++ b/pkg/webhooks/kubedb/v1/redis.go
@@ -100,6 +100,9 @@ func (w RedisCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Obje
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	redis, ok := obj.(*dbapi.Redis)
 	if !ok {
 		return nil, fmt.Errorf("expected a Redis but got a %T", obj)

--- a/pkg/webhooks/kubedb/v1/redissentinel.go
+++ b/pkg/webhooks/kubedb/v1/redissentinel.go
@@ -98,6 +98,9 @@ func (w RedisSentinelCustomWebhook) ValidateCreate(ctx context.Context, obj runt
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	sentinel, ok := obj.(*dbapi.RedisSentinel)
 	if !ok {
 		return nil, fmt.Errorf("expected a RedisSentinel but got a %T", obj)

--- a/pkg/webhooks/kubedb/v1alpha2/aerospike.go
+++ b/pkg/webhooks/kubedb/v1alpha2/aerospike.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	olddbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
+	amv "kubedb.dev/apimachinery/pkg/validator"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -77,6 +78,9 @@ var _ webhook.CustomValidator = &AerospikeCustomWebhook{}
 func (w *AerospikeCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	if isDeletionInProgress(obj) {
 		return nil, nil
+	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
 	}
 	ar, ok := obj.(*olddbapi.Aerospike)
 	if !ok {

--- a/pkg/webhooks/kubedb/v1alpha2/cassandra.go
+++ b/pkg/webhooks/kubedb/v1alpha2/cassandra.go
@@ -83,6 +83,9 @@ func (w *CassandraCustomWebhook) ValidateCreate(ctx context.Context, obj runtime
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	db, ok := obj.(*olddbapi.Cassandra)
 	if !ok {
 		return nil, fmt.Errorf("expected an Cassandra object but got %T", obj)

--- a/pkg/webhooks/kubedb/v1alpha2/clickhouse.go
+++ b/pkg/webhooks/kubedb/v1alpha2/clickhouse.go
@@ -79,6 +79,9 @@ func (w *ClickHouseCustomWebhook) ValidateCreate(ctx context.Context, obj runtim
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	db, ok := obj.(*olddbapi.ClickHouse)
 	if !ok {
 		return nil, fmt.Errorf("expected an ClickHouse object but got %T", obj)

--- a/pkg/webhooks/kubedb/v1alpha2/db2.go
+++ b/pkg/webhooks/kubedb/v1alpha2/db2.go
@@ -81,6 +81,9 @@ func (w *DB2CustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Objec
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	db, ok := obj.(*olddbapi.DB2)
 	if !ok {
 		return nil, fmt.Errorf("expected an DB2 object but got %T", obj)

--- a/pkg/webhooks/kubedb/v1alpha2/documentdb.go
+++ b/pkg/webhooks/kubedb/v1alpha2/documentdb.go
@@ -114,6 +114,9 @@ func (w *DocumentDBCustomWebhook) ValidateCreate(ctx context.Context, obj runtim
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	db, ok := obj.(*olddbapi.DocumentDB)
 	if !ok {
 		return nil, fmt.Errorf("expected an DocumentDB object but got %T", obj)

--- a/pkg/webhooks/kubedb/v1alpha2/druid.go
+++ b/pkg/webhooks/kubedb/v1alpha2/druid.go
@@ -24,6 +24,7 @@ import (
 	catalog "kubedb.dev/apimachinery/apis/catalog/v1alpha1"
 	"kubedb.dev/apimachinery/apis/kubedb"
 	olddbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
+	amv "kubedb.dev/apimachinery/pkg/validator"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -82,6 +83,9 @@ var _ webhook.CustomValidator = &DruidCustomWebhook{}
 func (w *DruidCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	if isDeletionInProgress(obj) {
 		return nil, nil
+	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
 	}
 	db, ok := obj.(*olddbapi.Druid)
 	if !ok {

--- a/pkg/webhooks/kubedb/v1alpha2/etcd.go
+++ b/pkg/webhooks/kubedb/v1alpha2/etcd.go
@@ -111,6 +111,9 @@ func (w *EtcdCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Obje
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	db, ok := obj.(*olddbapi.Etcd)
 	if !ok {
 		return nil, fmt.Errorf("expected an Etcd object, got a %T", obj)

--- a/pkg/webhooks/kubedb/v1alpha2/hanadb.go
+++ b/pkg/webhooks/kubedb/v1alpha2/hanadb.go
@@ -85,6 +85,9 @@ func (w *HanaDBCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Ob
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	db, ok := obj.(*api.HanaDB)
 	if !ok {
 		return nil, fmt.Errorf("expected a HanaDB object, got a %T", obj)

--- a/pkg/webhooks/kubedb/v1alpha2/hazelcast.go
+++ b/pkg/webhooks/kubedb/v1alpha2/hazelcast.go
@@ -24,6 +24,7 @@ import (
 	catalog "kubedb.dev/apimachinery/apis/catalog/v1alpha1"
 	"kubedb.dev/apimachinery/apis/kubedb"
 	olddbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
+	amv "kubedb.dev/apimachinery/pkg/validator"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -91,6 +92,9 @@ var _ webhook.CustomValidator = &HazelcastCustomWebhook{}
 func (w *HazelcastCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	if isDeletionInProgress(obj) {
 		return nil, nil
+	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
 	}
 	db, ok := obj.(*olddbapi.Hazelcast)
 	if !ok {

--- a/pkg/webhooks/kubedb/v1alpha2/ignite.go
+++ b/pkg/webhooks/kubedb/v1alpha2/ignite.go
@@ -24,6 +24,7 @@ import (
 	catalog "kubedb.dev/apimachinery/apis/catalog/v1alpha1"
 	"kubedb.dev/apimachinery/apis/kubedb"
 	olddbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
+	amv "kubedb.dev/apimachinery/pkg/validator"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -81,6 +82,9 @@ var _ webhook.CustomValidator = &IgniteCustomWebhook{}
 func (w *IgniteCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	if isDeletionInProgress(obj) {
 		return nil, nil
+	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
 	}
 	db, ok := obj.(*olddbapi.Ignite)
 	if !ok {

--- a/pkg/webhooks/kubedb/v1alpha2/kafka.go
+++ b/pkg/webhooks/kubedb/v1alpha2/kafka.go
@@ -24,6 +24,7 @@ import (
 	catalog "kubedb.dev/apimachinery/apis/catalog/v1alpha1"
 	"kubedb.dev/apimachinery/apis/kubedb"
 	olddbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
+	amv "kubedb.dev/apimachinery/pkg/validator"
 
 	errors2 "github.com/pkg/errors"
 	"gomodules.xyz/pointer"
@@ -78,6 +79,9 @@ var _ webhook.CustomValidator = &KafkaCustomWebhook{}
 func (w *KafkaCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	if isDeletionInProgress(obj) {
 		return nil, nil
+	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
 	}
 	db, ok := obj.(*olddbapi.Kafka)
 	if !ok {

--- a/pkg/webhooks/kubedb/v1alpha2/milvus.go
+++ b/pkg/webhooks/kubedb/v1alpha2/milvus.go
@@ -84,6 +84,9 @@ func (m *MilvusCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Ob
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, m.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	db, ok := obj.(*olddbapi.Milvus)
 	if !ok {
 		return nil, fmt.Errorf("expected a Milvus object, got a %T", obj)

--- a/pkg/webhooks/kubedb/v1alpha2/mssqlserver.go
+++ b/pkg/webhooks/kubedb/v1alpha2/mssqlserver.go
@@ -87,6 +87,9 @@ func (w *MSSQLServerCustomWebhook) ValidateCreate(ctx context.Context, obj runti
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	db, ok := obj.(*olddbapi.MSSQLServer)
 	if !ok {
 		return nil, fmt.Errorf("expected a MSSQLServer object, got a %T", obj)

--- a/pkg/webhooks/kubedb/v1alpha2/neo4j.go
+++ b/pkg/webhooks/kubedb/v1alpha2/neo4j.go
@@ -87,6 +87,9 @@ func (w *Neo4jCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Obj
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	db, ok := obj.(*olddbapi.Neo4j)
 	if !ok {
 		return nil, fmt.Errorf("expected an Neo4j object but got %T", obj)

--- a/pkg/webhooks/kubedb/v1alpha2/oracle.go
+++ b/pkg/webhooks/kubedb/v1alpha2/oracle.go
@@ -88,6 +88,9 @@ func (w *OracleCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Ob
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	db, ok := obj.(*olddbapi.Oracle)
 	if !ok {
 		return nil, fmt.Errorf("expected a Oracle object, got a %T", obj)

--- a/pkg/webhooks/kubedb/v1alpha2/pgpool.go
+++ b/pkg/webhooks/kubedb/v1alpha2/pgpool.go
@@ -90,6 +90,9 @@ func (w *PgpoolCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Ob
 	if isDeletionInProgress(obj) {
 		return nil, nil
 	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
+	}
 	pp, ok := obj.(*olddbapi.Pgpool)
 	if !ok {
 		return nil, fmt.Errorf("expected an pgpool object but got %T", obj)

--- a/pkg/webhooks/kubedb/v1alpha2/qdrant.go
+++ b/pkg/webhooks/kubedb/v1alpha2/qdrant.go
@@ -24,6 +24,7 @@ import (
 	catalog "kubedb.dev/apimachinery/apis/catalog/v1alpha1"
 	"kubedb.dev/apimachinery/apis/kubedb"
 	olddbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
+	amv "kubedb.dev/apimachinery/pkg/validator"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -80,6 +81,9 @@ var _ webhook.CustomValidator = &QdrantCustomWebhook{}
 func (w *QdrantCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	if isDeletionInProgress(obj) {
 		return nil, nil
+	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
 	}
 	db, ok := obj.(*olddbapi.Qdrant)
 	if !ok {

--- a/pkg/webhooks/kubedb/v1alpha2/rabbitmq.go
+++ b/pkg/webhooks/kubedb/v1alpha2/rabbitmq.go
@@ -24,6 +24,7 @@ import (
 	catalog "kubedb.dev/apimachinery/apis/catalog/v1alpha1"
 	"kubedb.dev/apimachinery/apis/kubedb"
 	olddbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
+	amv "kubedb.dev/apimachinery/pkg/validator"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -81,6 +82,9 @@ var _ webhook.CustomValidator = &RabbitMQCustomWebhook{}
 func (w *RabbitMQCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	if isDeletionInProgress(obj) {
 		return nil, nil
+	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
 	}
 	db, ok := obj.(*olddbapi.RabbitMQ)
 	if !ok {

--- a/pkg/webhooks/kubedb/v1alpha2/singlestore.go
+++ b/pkg/webhooks/kubedb/v1alpha2/singlestore.go
@@ -23,6 +23,7 @@ import (
 	catalog "kubedb.dev/apimachinery/apis/catalog/v1alpha1"
 	"kubedb.dev/apimachinery/apis/kubedb"
 	olddbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
+	amv "kubedb.dev/apimachinery/pkg/validator"
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -80,6 +81,9 @@ var _ webhook.CustomValidator = &SinglestoreCustomWebhook{}
 func (w *SinglestoreCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	if isDeletionInProgress(obj) {
 		return nil, nil
+	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
 	}
 	db, ok := obj.(*olddbapi.Singlestore)
 	if !ok {

--- a/pkg/webhooks/kubedb/v1alpha2/solr.go
+++ b/pkg/webhooks/kubedb/v1alpha2/solr.go
@@ -26,6 +26,7 @@ import (
 	catalog "kubedb.dev/apimachinery/apis/catalog/v1alpha1"
 	"kubedb.dev/apimachinery/apis/kubedb"
 	olddbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
+	amv "kubedb.dev/apimachinery/pkg/validator"
 
 	"github.com/coreos/go-semver/semver"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -83,6 +84,9 @@ var _ webhook.CustomValidator = &SolrCustomWebhook{}
 func (w *SolrCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	if isDeletionInProgress(obj) {
 		return nil, nil
+	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
 	}
 	db, ok := obj.(*olddbapi.Solr)
 	if !ok {

--- a/pkg/webhooks/kubedb/v1alpha2/weaviate.go
+++ b/pkg/webhooks/kubedb/v1alpha2/weaviate.go
@@ -24,6 +24,7 @@ import (
 	catalog "kubedb.dev/apimachinery/apis/catalog/v1alpha1"
 	"kubedb.dev/apimachinery/apis/kubedb"
 	olddbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
+	amv "kubedb.dev/apimachinery/pkg/validator"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,6 +77,9 @@ var _ webhook.CustomValidator = &WeaviateCustomWebhook{}
 func (w *WeaviateCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	if isDeletionInProgress(obj) {
 		return nil, nil
+	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
 	}
 	db, ok := obj.(*olddbapi.Weaviate)
 	if !ok {

--- a/pkg/webhooks/kubedb/v1alpha2/zookeeper.go
+++ b/pkg/webhooks/kubedb/v1alpha2/zookeeper.go
@@ -24,6 +24,7 @@ import (
 	"kubedb.dev/apimachinery/apis/catalog/v1alpha1"
 	"kubedb.dev/apimachinery/apis/kubedb"
 	olddbapi "kubedb.dev/apimachinery/apis/kubedb/v1alpha2"
+	amv "kubedb.dev/apimachinery/pkg/validator"
 
 	core "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -81,6 +82,9 @@ var _ webhook.CustomValidator = &ZooKeeperCustomWebhook{}
 func (w *ZooKeeperCustomWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	if isDeletionInProgress(obj) {
 		return nil, nil
+	}
+	if err := amv.ValidateNameUniqueness(ctx, w.DefaultClient, obj); err != nil {
+		return nil, err
 	}
 	db, ok := obj.(*olddbapi.ZooKeeper)
 	if !ok {


### PR DESCRIPTION
Every kubedb create webhook now rejects the object if another kubedb database in the same namespace already carries that name — e.g. with `Postgres demo/ha` present, `MongoDB demo/ha` is refused.

- `pkg/validator/name_uniqueness.go`: `ValidateNameUniqueness` enumerates the `kubedb.com` kinds from the manager scheme (one GVK per kind, preferring `v1` > `v1alpha2` > `v1alpha1`, since one CR is served under several versions), skips the incoming object's own kind (same-kind collisions are the API server's job), and does a live `GET ns/name` per kind with an unstructured object (unstructured bypasses the controller-runtime cache, so no new informers). `NotFound` and `NoMatch` (CRD not installed) are skipped; any other error fails admission.
- Wired into `ValidateCreate` of all 34 webhooks under `pkg/webhooks/kubedb/{v1,v1alpha2}`, right after the `isDeletionInProgress` guard. Updates are untouched.

Note: the webhook's service account needs `get` on the kubedb resources; a Forbidden response fails the create rather than being silently skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added name uniqueness validation for database resources during creation.
  * Resource names must now be unique within their namespace across supported database types.
  * Creation requests with conflicting names are rejected with a validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->