### PR TITLE
add OsbwsPFilePath in constant

### DIFF
--- a/apis/kubedb/constants.go
+++ b/apis/kubedb/constants.go
@@ -2362,6 +2362,9 @@ const (
 	OracleSharedTlsVolumeMountPath = "/tls/certs"
 
 	OracleCustomConfigFileName = "oracle.cnf"
+
+	OracleDefaultOSBWSPFilePath = OracleDataDir + "/osbws" + OracleDatabaseServiceName + ".ora"
+	OracleOsbwsPFilePathFormat  = OracleDataDir + "/osbws%s.ora"
 )
 
 // =========================== DB2 Constants ============================


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for standard Oracle OSBWS configuration file locations.
  - Added service-specific path formatting for Oracle OSBWS parameter files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->