### PR TITLE
Milvus: support TLS, password auth and encrypted storage for self-managed meta etcd

### DIFF
--- a/apis/kubedb/constants.go
+++ b/apis/kubedb/constants.go
@@ -925,10 +925,23 @@ const (
 	MilvusContainerName = "milvus"
 
 	EtcdEndpointsName = "ETCD_ENDPOINTS"
-	EtcdAPIVersion    = "operator.etcd.io/v1alpha1"
-	EtcdKind          = "EtcdCluster"
 	ControllerName    = "milvus-controller"
 	EtcdName          = "etcd"
+
+	// MilvusMetaEtcdTLSVolName / MilvusMetaEtcdTLSMountPath mount the internally
+	// managed meta etcd's client certificate (ca.crt/tls.crt/tls.key) into the
+	// milvus containers when spec.metaStorage.tls is configured.
+	MilvusMetaEtcdTLSVolName   = "meta-etcd-tls"
+	MilvusMetaEtcdTLSMountPath = "/milvus/etcd-tls"
+
+	// VirtualSecretsMetaEtcdVolume / VirtualSecretsMetaEtcdVolumeMountPath surface
+	// the internally managed meta etcd's virtual auth secret (when
+	// spec.metaStorage.authSecret is a virtual secret) as files, mirroring
+	// VirtualSecretsVolume but keyed off the meta etcd's own SecretProviderClass.
+	VirtualSecretsMetaEtcdVolume          = "virtual-secrets-meta-etcd"
+	VirtualSecretsMetaEtcdVolumeMountPath = "/var/run/secrets/virtual-secrets-meta-etcd"
+	VirtualSecretsMetaEtcdKeyUsername     = "vs://" + VirtualSecretsMetaEtcdVolumeMountPath + "/" + core.BasicAuthUsernameKey
+	VirtualSecretsMetaEtcdKeyPassword     = "vs://" + VirtualSecretsMetaEtcdVolumeMountPath + "/" + core.BasicAuthPasswordKey
 
 	MinioAddressName   = "MINIO_ADDRESS"
 	MinioAddressKey    = "address"

--- a/apis/kubedb/v1alpha2/milvus_helpers.go
+++ b/apis/kubedb/v1alpha2/milvus_helpers.go
@@ -219,6 +219,44 @@ func (m *Milvus) EtcdServiceName() string {
 	return fmt.Sprintf("%s-%s", m.Name, kubedb.EtcdName)
 }
 
+// internalMetaEtcd returns a throwaway Etcd value describing the internally
+// managed meta-storage etcd cluster this Milvus creates (see
+// pkg/controller/dependency.go in the milvus operator). Milvus and Etcd live in
+// the same v1alpha2 package, so its own naming/URL helpers are reused here
+// instead of duplicating DNS-building logic.
+func (m *Milvus) internalMetaEtcd() *Etcd {
+	e := &Etcd{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      m.EtcdServiceName(),
+			Namespace: m.Namespace,
+		},
+	}
+	if m.Spec.MetaStorage != nil {
+		e.Spec.TLS = m.Spec.MetaStorage.TLS
+		e.Spec.AuthSecret = m.Spec.MetaStorage.AuthSecret
+	}
+	return e
+}
+
+// MetaStorageTLSEnabled reports whether the internally-managed meta etcd has
+// TLS configured. Always false when meta storage is externally managed.
+func (m *Milvus) MetaStorageTLSEnabled() bool {
+	return m.Spec.MetaStorage != nil && !m.Spec.MetaStorage.ExternallyManaged && m.Spec.MetaStorage.TLS != nil
+}
+
+// MetaStorageClientCertSecretName returns the internally-managed meta etcd's
+// client certificate secret name, or "" if TLS is disabled.
+func (m *Milvus) MetaStorageClientCertSecretName() string {
+	return m.internalMetaEtcd().GetCertSecretName(EtcdClientCert)
+}
+
+// MetaStorageAuthSecretName returns the internally-managed meta etcd's root
+// auth secret name (BYO name if spec.metaStorage.authSecret.name is set, else
+// the conventional "<etcd-name>-auth").
+func (m *Milvus) MetaStorageAuthSecretName() string {
+	return m.internalMetaEtcd().GetAuthSecretName()
+}
+
 func (m *Milvus) MetaStorageEndpoints() []string {
 	if m.Spec.MetaStorage.ExternallyManaged {
 		if len(m.Spec.MetaStorage.Endpoints) == 0 {
@@ -228,16 +266,12 @@ func (m *Milvus) MetaStorageEndpoints() []string {
 		return m.Spec.MetaStorage.Endpoints
 	}
 
+	e := m.internalMetaEtcd()
 	size := m.Spec.MetaStorage.Size
 
 	endpoints := make([]string, size)
 	for i := range size {
-		endpoints[i] = fmt.Sprintf(
-			"http://%s-%d.%s.%s.svc.cluster.local:%d",
-			m.EtcdServiceName(), i,
-			m.EtcdServiceName(), m.Namespace,
-			2379,
-		)
+		endpoints[i] = e.ClientURL(e.PodName(i))
 	}
 
 	return endpoints

--- a/apis/kubedb/v1alpha2/milvus_types.go
+++ b/apis/kubedb/v1alpha2/milvus_types.go
@@ -215,6 +215,18 @@ type MetaStorageSpec struct {
 	// Storage to specify how storage shall be used.
 	// +optional
 	Storage *core.PersistentVolumeClaimSpec `json:"storage,omitempty"`
+
+	// TLS configures certificates issued from spec.metaStorage.tls.issuerRef for
+	// the internally-managed meta etcd's client, server and peer traffic.
+	// Only used when ExternallyManaged is false.
+	// +optional
+	TLS *kmapi.TLSConfig `json:"tls,omitempty"`
+
+	// AuthSecret is the root credential for the internally-managed meta etcd.
+	// If omitted, the etcd operator auto-generates one. Only used when
+	// ExternallyManaged is false.
+	// +optional
+	AuthSecret *SecretReference `json:"authSecret,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/apis/kubedb/v1alpha2/openapi_generated.go
+++ b/apis/kubedb/v1alpha2/openapi_generated.go
@@ -40525,11 +40525,23 @@ func schema_apimachinery_apis_kubedb_v1alpha2_MetaStorageSpec(ref common.Referen
 							Ref:         ref("k8s.io/api/core/v1.PersistentVolumeClaimSpec"),
 						},
 					},
+					"tls": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TLS configures certificates issued from spec.metaStorage.tls.issuerRef for the internally-managed meta etcd's client, server and peer traffic. Only used when ExternallyManaged is false.",
+							Ref:         ref("kmodules.xyz/client-go/api/v1.TLSConfig"),
+						},
+					},
+					"authSecret": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AuthSecret is the root credential for the internally-managed meta etcd. If omitted, the etcd operator auto-generates one. Only used when ExternallyManaged is false.",
+							Ref:         ref("kubedb.dev/apimachinery/apis/kubedb/v1alpha2.SecretReference"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.PersistentVolumeClaimSpec"},
+			"k8s.io/api/core/v1.PersistentVolumeClaimSpec", "kmodules.xyz/client-go/api/v1.TLSConfig", "kubedb.dev/apimachinery/apis/kubedb/v1alpha2.SecretReference"},
 	}
 }
 

--- a/apis/kubedb/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/kubedb/v1alpha2/zz_generated.deepcopy.go
@@ -4236,6 +4236,16 @@ func (in *MetaStorageSpec) DeepCopyInto(out *MetaStorageSpec) {
 		*out = new(corev1.PersistentVolumeClaimSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.TLS != nil {
+		in, out := &in.TLS, &out.TLS
+		*out = new(apiv1.TLSConfig)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.AuthSecret != nil {
+		in, out := &in.AuthSecret, &out.AuthSecret
+		*out = new(SecretReference)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/crds/gitops.kubedb.com_milvuses.yaml
+++ b/crds/gitops.kubedb.com_milvuses.yaml
@@ -115,6 +115,7 @@ spec:
                     - kind
                     - name
                     type: object
+                    x-kubernetes-map-type: atomic
                   endpoints:
                     items:
                       type: string

--- a/crds/gitops.kubedb.com_milvuses.yaml
+++ b/crds/gitops.kubedb.com_milvuses.yaml
@@ -92,6 +92,29 @@ spec:
                 type: object
               metaStorage:
                 properties:
+                  authSecret:
+                    properties:
+                      activeFrom:
+                        format: date-time
+                        type: string
+                      apiGroup:
+                        default: ""
+                        type: string
+                      externallyManaged:
+                        type: boolean
+                      kind:
+                        default: Secret
+                        type: string
+                      name:
+                        type: string
+                      rotateAfter:
+                        type: string
+                      secretStoreName:
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
                   endpoints:
                     items:
                       type: string
@@ -195,6 +218,107 @@ spec:
                     - Durable
                     - Ephemeral
                     type: string
+                  tls:
+                    properties:
+                      certificates:
+                        items:
+                          properties:
+                            alias:
+                              type: string
+                            dnsNames:
+                              items:
+                                type: string
+                              type: array
+                            duration:
+                              type: string
+                            emailAddresses:
+                              items:
+                                type: string
+                              type: array
+                            ipAddresses:
+                              items:
+                                type: string
+                              type: array
+                            issuerRef:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            privateKey:
+                              properties:
+                                encoding:
+                                  enum:
+                                  - PKCS1
+                                  - PKCS8
+                                  type: string
+                              type: object
+                            renewBefore:
+                              type: string
+                            secretName:
+                              type: string
+                            subject:
+                              properties:
+                                countries:
+                                  items:
+                                    type: string
+                                  type: array
+                                localities:
+                                  items:
+                                    type: string
+                                  type: array
+                                organizationalUnits:
+                                  items:
+                                    type: string
+                                  type: array
+                                organizations:
+                                  items:
+                                    type: string
+                                  type: array
+                                postalCodes:
+                                  items:
+                                    type: string
+                                  type: array
+                                provinces:
+                                  items:
+                                    type: string
+                                  type: array
+                                serialNumber:
+                                  type: string
+                                streetAddresses:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            uris:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - alias
+                          type: object
+                        type: array
+                      issuerRef:
+                        properties:
+                          apiGroup:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
                 type: object
               monitor:
                 properties:

--- a/crds/kubedb.com_milvuses.yaml
+++ b/crds/kubedb.com_milvuses.yaml
@@ -132,6 +132,7 @@ spec:
                     - kind
                     - name
                     type: object
+                    x-kubernetes-map-type: atomic
                   endpoints:
                     items:
                       type: string

--- a/crds/kubedb.com_milvuses.yaml
+++ b/crds/kubedb.com_milvuses.yaml
@@ -109,6 +109,29 @@ spec:
                 type: object
               metaStorage:
                 properties:
+                  authSecret:
+                    properties:
+                      activeFrom:
+                        format: date-time
+                        type: string
+                      apiGroup:
+                        default: ""
+                        type: string
+                      externallyManaged:
+                        type: boolean
+                      kind:
+                        default: Secret
+                        type: string
+                      name:
+                        type: string
+                      rotateAfter:
+                        type: string
+                      secretStoreName:
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
                   endpoints:
                     items:
                       type: string
@@ -212,6 +235,107 @@ spec:
                     - Durable
                     - Ephemeral
                     type: string
+                  tls:
+                    properties:
+                      certificates:
+                        items:
+                          properties:
+                            alias:
+                              type: string
+                            dnsNames:
+                              items:
+                                type: string
+                              type: array
+                            duration:
+                              type: string
+                            emailAddresses:
+                              items:
+                                type: string
+                              type: array
+                            ipAddresses:
+                              items:
+                                type: string
+                              type: array
+                            issuerRef:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            privateKey:
+                              properties:
+                                encoding:
+                                  enum:
+                                  - PKCS1
+                                  - PKCS8
+                                  type: string
+                              type: object
+                            renewBefore:
+                              type: string
+                            secretName:
+                              type: string
+                            subject:
+                              properties:
+                                countries:
+                                  items:
+                                    type: string
+                                  type: array
+                                localities:
+                                  items:
+                                    type: string
+                                  type: array
+                                organizationalUnits:
+                                  items:
+                                    type: string
+                                  type: array
+                                organizations:
+                                  items:
+                                    type: string
+                                  type: array
+                                postalCodes:
+                                  items:
+                                    type: string
+                                  type: array
+                                provinces:
+                                  items:
+                                    type: string
+                                  type: array
+                                serialNumber:
+                                  type: string
+                                streetAddresses:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            uris:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - alias
+                          type: object
+                        type: array
+                      issuerRef:
+                        properties:
+                          apiGroup:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
                 type: object
               monitor:
                 properties:

--- a/pkg/webhooks/kubedb/v1alpha2/milvus.go
+++ b/pkg/webhooks/kubedb/v1alpha2/milvus.go
@@ -205,6 +205,25 @@ func (m *MilvusCustomWebhook) ValidateCreateOrUpdate(db *olddbapi.Milvus) field.
 		}
 	}
 
+	if meta := db.Spec.MetaStorage; meta != nil {
+		if meta.ExternallyManaged {
+			if meta.TLS != nil {
+				allErr = append(allErr, field.Invalid(field.NewPath("spec").Child("metaStorage").Child("tls"),
+					db.Name, "spec.metaStorage.tls is only used when metaStorage is not externally managed"))
+			}
+			if meta.AuthSecret != nil {
+				allErr = append(allErr, field.Invalid(field.NewPath("spec").Child("metaStorage").Child("authSecret"),
+					db.Name, "spec.metaStorage.authSecret is only used when metaStorage is not externally managed"))
+			}
+		} else if meta.TLS != nil && meta.TLS.IssuerRef == nil {
+			allErr = append(allErr, field.Invalid(
+				field.NewPath("spec").Child("metaStorage").Child("tls").Child("issuerRef"),
+				db.Name,
+				"spec.metaStorage.tls.issuerRef is required when metaStorage.tls is configured",
+			))
+		}
+	}
+
 	if len(allErr) == 0 {
 		return nil
 	}


### PR DESCRIPTION
## What

Extends `spec.metaStorage` on `Milvus` with `tls` and `authSecret` fields, mirroring the fields already on the `Etcd` CRD's spec. This is the apimachinery half of switching Milvus's internal ("self-managed") meta-storage etcd from the official `go.etcd.io/etcd-operator` integration over to KubeDB's own `kubedb.dev/etcd` operator (companion PR in `kubedb/milvus`).

Both new fields only apply when `spec.metaStorage.externallyManaged` is `false` (the default): the Milvus operator creates a KubeDB `Etcd` CR for the meta storage cluster, and these fields pass straight through to it.

- `spec.metaStorage.tls` - TLS (server/client/peer certs) for the internal meta etcd, same shape as `Etcd.spec.tls`.
- `spec.metaStorage.authSecret` - etcd RBAC root credential for the internal meta etcd, same shape as `Etcd.spec.authSecret`. If omitted, the etcd operator auto-generates one.
- Encrypted storage needs no new field: `spec.metaStorage.storage` already carries a full `PersistentVolumeClaimSpec`, so pointing `storageClassName` at an encrypted-volume StorageClass is enough.

## Other changes

- Rebuilt `Milvus.MetaStorageEndpoints()` on top of `Etcd`'s own naming helpers (`ClientURL`/`PodName`) instead of hand-rolled DNS strings (Milvus and Etcd share the `v1alpha2` package). The old hand-rolled pattern had already drifted from what a real `Etcd` CR creates (governing service `-pods` suffix, TLS scheme).
- Added `MetaStorageTLSEnabled`/`MetaStorageClientCertSecretName`/`MetaStorageAuthSecretName` helpers for the milvus operator to consume.
- Webhook validation: `metaStorage.tls`/`metaStorage.authSecret` are rejected when `externallyManaged` is true; `metaStorage.tls` requires an `issuerRef`.
- Dropped the now-unused `EtcdAPIVersion`/`EtcdKind` constants (`operator.etcd.io/v1alpha1` / `EtcdCluster`) - only referenced by the milvus operator's old official-etcd-operator integration, removed in the companion PR.

## Testing

`go build`/`go vet` on `./apis/...`, `./pkg/webhooks/...`, `./client/...`, `./pkg/controller/...`. No live-cluster verification in this change (paired `kubedb/milvus` PR carries the functional wiring).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TLS and authentication configuration for internally managed Milvus meta-storage.
  * Added CRD configuration fields for meta-storage certificates and credential secrets.
  * Meta-storage endpoints now support configured security settings.

* **Bug Fixes**
  * Added validation to prevent unsupported security settings for externally managed meta-storage.
  * Added validation requiring a certificate issuer when TLS is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->